### PR TITLE
feature/task-2468_entity_copy_engine

### DIFF
--- a/Collections/Unsafe/UnsafeArray.cs
+++ b/Collections/Unsafe/UnsafeArray.cs
@@ -27,13 +27,13 @@ namespace Sapientia.Collections
 
 		public readonly Id<MemoryManager> memoryId;
 
-		public int Length
+		public readonly int Length
 		{
 			[MethodImpl(MethodImplOptions.AggressiveInlining)]
 			get => _length;
 		}
 
-		public bool IsCreated => ptr != default;
+		public readonly bool IsCreated => ptr != default;
 
 		public UnsafeArray(int length = 8, ClearOptions clearMemory = ClearOptions.ClearMemory) : this(default, length, clearMemory)
 		{
@@ -58,7 +58,7 @@ namespace Sapientia.Collections
 			get => ptr.Slice(Length - 1, 1);
 		}
 
-		public ref T this[int index]
+		public readonly ref T this[int index]
 		{
 			[MethodImpl(MethodImplOptions.AggressiveInlining)]
 			get => ref ptr[index];

--- a/Collections/Unsafe/UnsafeBitArray.cs
+++ b/Collections/Unsafe/UnsafeBitArray.cs
@@ -33,6 +33,10 @@ namespace Sapientia.Collections
 
 		public readonly Id<MemoryManager> memoryId;
 
+		public UnsafeBitArray(int numBits) : this(default, numBits)
+		{
+		}
+
 		/// <summary>
 		/// Initializes and returns an instance of UnsafeBitArray.
 		/// </summary>

--- a/Collections/Unsafe/UnsafeDictionary.cs
+++ b/Collections/Unsafe/UnsafeDictionary.cs
@@ -162,7 +162,7 @@ namespace Sapientia.Collections
 		}
 
 		[MethodImpl(MethodImplOptions.AggressiveInlining)]
-		public bool TryGetValue(TKey key, out TValue value)
+		public readonly bool TryGetValue(TKey key, out TValue value)
 		{
 			var entry = FindEntry(key);
 			if (entry >= 0)
@@ -173,6 +173,12 @@ namespace Sapientia.Collections
 
 			value = UnsafeExt.DefaultRefReadonly<TValue>();
 			return false;
+		}
+
+		[MethodImpl(MethodImplOptions.AggressiveInlining)]
+		public readonly TValue GetOrDefault(TKey key, TValue defaultValue = default)
+		{
+			return TryGetValue(key, out var value) ? value : defaultValue;
 		}
 
 		[MethodImpl(MethodImplOptions.AggressiveInlining)]
@@ -239,7 +245,7 @@ namespace Sapientia.Collections
 		}
 
 		[MethodImpl(MethodImplOptions.AggressiveInlining)]
-		private int FindEntry(in TKey key)
+		private readonly int FindEntry(in TKey key)
 		{
 			if (_buckets.IsCreated)
 			{

--- a/Collections/Unsafe/UnsafeSparseSet.cs
+++ b/Collections/Unsafe/UnsafeSparseSet.cs
@@ -209,6 +209,7 @@ namespace Sapientia.Collections
 			ref var valueA = ref (_values.ptr + denseId).Value();
 			ref var valueB = ref (_values.ptr + _count).Value();
 
+			removedValue = valueA;
 			valueA = valueB;
 			valueB = default;
 

--- a/MemoryAllocator/State/Copy.meta
+++ b/MemoryAllocator/State/Copy.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 7e709ececfc20e942ab5e64304df1c08
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/MemoryAllocator/State/Copy/ComponentCopier.cs
+++ b/MemoryAllocator/State/Copy/ComponentCopier.cs
@@ -1,0 +1,89 @@
+using System;
+using System.Collections;
+using Sapientia.Collections;
+using Sapientia.TypeIndexer;
+
+namespace Sapientia.MemoryAllocator.State
+{
+	/// <summary>
+	/// Диспатч копира по локальному индексу компонента (<see cref="TypeId{IComponent}"/>). Генератор запекает
+	/// per-type thunk-и в массивы делегатов и метит биты копируемости/пропуска — тело диспатча не генерируется.
+	/// Лог о необработанном компоненте уходит в код игры через зарегистрированный делегат: Sapientia не видит WLog.
+	/// </summary>
+	public sealed class ComponentCopier : IComponentCopier
+	{
+		public delegate void AppendDelegate(WorldState world, Entity entity, ref UnsafeList<Entity> frontier);
+
+		public delegate void CopyDelegate(WorldState oldWS, WorldState newWS, Entity oldEntity, Entity newEntity, in UnsafeDictionary<Entity, Entity> map);
+
+		private readonly AppendDelegate?[] _append;
+		private readonly CopyDelegate?[] _copy;
+		private readonly BitArray _copiable;
+		private readonly BitArray _skipped;
+		private Action<TypeId<IComponent>>? _reportUnhandled;
+
+		public ComponentCopier()
+		{
+			// Count готов к BeforeSceneLoad (выставляется в IndexedTypesInitializer раньше, на BeforeSplashScreen).
+			var count = TypeId<IComponent>.Count;
+			_append = new AppendDelegate?[count];
+			_copy = new CopyDelegate?[count];
+			_copiable = new BitArray(count);
+			_skipped = new BitArray(count);
+		}
+
+		/// <summary>
+		/// Регистрирует thunk-и компонента по локальному индексу. У плоского компонента <paramref name="append"/>
+		/// = null (дочерних сущностей нет).
+		/// </summary>
+		public void Register(int localId, AppendDelegate? append, CopyDelegate copy)
+		{
+			_append[localId] = append;
+			_copy[localId] = copy;
+			_copiable[localId] = true;
+		}
+
+		/// <summary>
+		/// Метит компонент как намеренно не копируемый (<see cref="SkipCopyAttribute"/>).
+		/// </summary>
+		public void MarkSkipped(int localId)
+		{
+			_skipped[localId] = true;
+		}
+
+		/// <summary>
+		/// Регистрирует мост в код игры для лога о необработанном компоненте (WLog в Sapientia не виден).
+		/// </summary>
+		public void SetUnhandledReporter(Action<TypeId<IComponent>> reporter)
+		{
+			_reportUnhandled = reporter;
+		}
+
+		public bool IsCopiable(TypeId<IComponent> typeId)
+		{
+			return _copiable[(int)typeId];
+		}
+
+		public bool IsSkipped(TypeId<IComponent> typeId)
+		{
+			return _skipped[(int)typeId];
+		}
+
+		public void AppendEntities(TypeId<IComponent> typeId, WorldState world, Entity entity, ref UnsafeList<Entity> frontier)
+		{
+			// У плоского компонента append = null: дочерних сущностей нет, складывать нечего.
+			_append[(int)typeId]?.Invoke(world, entity, ref frontier);
+		}
+
+		public void CopyComponent(TypeId<IComponent> typeId, WorldState oldWS, WorldState newWS, Entity oldEntity, Entity newEntity, in UnsafeDictionary<Entity, Entity> map)
+		{
+			// Зовётся только после IsCopiable == true, поэтому copy-делегат заведомо не null.
+			_copy[(int)typeId]!.Invoke(oldWS, newWS, oldEntity, newEntity, in map);
+		}
+
+		public void ReportUnhandled(TypeId<IComponent> typeId)
+		{
+			_reportUnhandled?.Invoke(typeId);
+		}
+	}
+}

--- a/MemoryAllocator/State/Copy/ComponentCopier.cs
+++ b/MemoryAllocator/State/Copy/ComponentCopier.cs
@@ -61,24 +61,24 @@ namespace Sapientia.MemoryAllocator.State
 
 		public bool IsCopiable(TypeId<IComponent> typeId)
 		{
-			return _copiable[(int)typeId];
+			return _copiable[typeId];
 		}
 
 		public bool IsSkipped(TypeId<IComponent> typeId)
 		{
-			return _skipped[(int)typeId];
+			return _skipped[typeId];
 		}
 
 		public void AppendEntities(TypeId<IComponent> typeId, WorldState world, Entity entity, ref UnsafeList<Entity> frontier)
 		{
 			// У плоского компонента append = null: дочерних сущностей нет, складывать нечего.
-			_append[(int)typeId]?.Invoke(world, entity, ref frontier);
+			_append[typeId]?.Invoke(world, entity, ref frontier);
 		}
 
 		public void CopyComponent(TypeId<IComponent> typeId, WorldState oldWS, WorldState newWS, Entity oldEntity, Entity newEntity, in UnsafeDictionary<Entity, Entity> map)
 		{
 			// Зовётся только после IsCopiable == true, поэтому copy-делегат заведомо не null.
-			_copy[(int)typeId]!.Invoke(oldWS, newWS, oldEntity, newEntity, in map);
+			_copy[typeId]!.Invoke(oldWS, newWS, oldEntity, newEntity, in map);
 		}
 
 		public void ReportUnhandled(TypeId<IComponent> typeId)

--- a/MemoryAllocator/State/Copy/ComponentCopier.cs.meta
+++ b/MemoryAllocator/State/Copy/ComponentCopier.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 205eb5a389a078b4583cccadfd7fa108

--- a/MemoryAllocator/State/Copy/EntityCopyMarkers.cs
+++ b/MemoryAllocator/State/Copy/EntityCopyMarkers.cs
@@ -1,0 +1,28 @@
+using System;
+
+namespace Sapientia.MemoryAllocator.State
+{
+	/// <summary>
+	/// Метка: сущность не копируется (например, моб или игрок). В обходе её пропускают, а ссылки на неё
+	/// заменяют на <see cref="Entity.EMPTY"/>.
+	/// </summary>
+	public struct IgnoreEntityCopy : IComponent {}
+
+	/// <summary>
+	/// Компонент пишет реализацию <see cref="ICopiable{T}"/> вручную. Генератор его пропускает.
+	/// </summary>
+	[AttributeUsage(AttributeTargets.Struct)]
+	public sealed class ManualCopyAttribute : Attribute {}
+
+	/// <summary>
+	/// Компонент не копируется (временные данные навигации или физики - в новом мире создаются заново).
+	/// </summary>
+	[AttributeUsage(AttributeTargets.Struct)]
+	public sealed class SkipCopyAttribute : Attribute {}
+
+	/// <summary>
+	/// Поле при копировании обнуляется и не попадает в AppendEntities.
+	/// </summary>
+	[AttributeUsage(AttributeTargets.Field)]
+	public sealed class IgnoreCopyAttribute : Attribute {}
+}

--- a/MemoryAllocator/State/Copy/EntityCopyMarkers.cs
+++ b/MemoryAllocator/State/Copy/EntityCopyMarkers.cs
@@ -9,7 +9,16 @@ namespace Sapientia.MemoryAllocator.State
 	public struct IgnoreEntityCopy : IComponent {}
 
 	/// <summary>
-	/// Компонент пишет реализацию <see cref="ICopiable{T}"/> вручную. Генератор его пропускает.
+	/// Генератор пишет partial <see cref="ICopiable{T}"/> для этого ссылочного компонента. Ставится
+	/// вместе с partial, когда компонент вводят в копирование. Плоским компонентам не нужен — они
+	/// копируются значением без интерфейса. Без метки ссылочный компонент идёт в лог-отчёт (worklist).
+	/// </summary>
+	[AttributeUsage(AttributeTargets.Struct)]
+	public sealed class GenerateCopyAttribute : Attribute {}
+
+	/// <summary>
+	/// Компонент реализует <see cref="ICopiable{T}"/> вручную (держатели union-структур). Генератор
+	/// partial не пишет, но компонент попадает в диспатч.
 	/// </summary>
 	[AttributeUsage(AttributeTargets.Struct)]
 	public sealed class ManualCopyAttribute : Attribute {}
@@ -19,6 +28,20 @@ namespace Sapientia.MemoryAllocator.State
 	/// </summary>
 	[AttributeUsage(AttributeTargets.Struct)]
 	public sealed class SkipCopyAttribute : Attribute {}
+
+	/// <summary>
+	/// Поле-сущность принадлежит компоненту (дочерняя). Кладётся в обход и копируется. Без метки поле
+	/// <see cref="Entity"/> считается ссылкой на чужую сущность — только перенастройка, в обход не идёт.
+	/// </summary>
+	[AttributeUsage(AttributeTargets.Field)]
+	public sealed class OwnedAttribute : Attribute {}
+
+	/// <summary>
+	/// Коллекция сущностей — это ссылки на чужие сущности, не владение. В обход не кладётся, только
+	/// поэлементная перенастройка. Без метки коллекция <see cref="Entity"/> считается владением.
+	/// </summary>
+	[AttributeUsage(AttributeTargets.Field)]
+	public sealed class LinkAttribute : Attribute {}
 
 	/// <summary>
 	/// Поле при копировании обнуляется и не попадает в AppendEntities.

--- a/MemoryAllocator/State/Copy/EntityCopyMarkers.cs.meta
+++ b/MemoryAllocator/State/Copy/EntityCopyMarkers.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 89ae13b3fd3070842a2645ca1cad3155

--- a/MemoryAllocator/State/Copy/EntityTreeCopier.cs
+++ b/MemoryAllocator/State/Copy/EntityTreeCopier.cs
@@ -1,0 +1,179 @@
+using System;
+using Sapientia.Collections;
+
+namespace Sapientia.MemoryAllocator.State
+{
+	/// <summary>
+	/// Обход и копирование поддеревьев сущностей в другой мир за один батч (один раз, при переходе между
+	/// этапами). Три прохода: собрать все поддеревья (<see cref="CollectAll"/>); создать все копии и запомнить
+	/// пары старая-новая (<see cref="CreateCopies"/>); скопировать значения и перенастроить ссылки
+	/// (<see cref="CopyValues"/>). Три, а не два, потому что для перенастройки ссылки новая сущность уже должна
+	/// существовать. Буферы off-arena, освобождаются в <see cref="Dispose"/>.
+	/// </summary>
+	public struct EntityTreeCopier : IDisposable
+	{
+		private readonly WorldState _srcWorld;
+		private readonly WorldState _dstWorld;
+		private readonly bool _hasIgnoreSet;
+
+		private UnsafeList<Entity> _toCopy;
+		private UnsafeBitArray _visited;
+		private UnsafeList<Entity> _frontier;
+		private UnsafeDictionary<Entity, Entity> _map;
+
+		public EntityTreeCopier(WorldState srcWorld, WorldState dstWorld)
+		{
+			_srcWorld = srcWorld;
+			_dstWorld = dstWorld;
+			// Набор для метки может быть не зарегистрирован; тогда метки нет ни на одной сущности.
+			_hasIgnoreSet = srcWorld.HasComponentSet<IgnoreEntityCopy>();
+
+			// visited - бит-сет по entity.id (ushort): id всех живых сущностей исходного мира < EntitiesCapacity.
+			var entitiesCapacity = srcWorld.GetService<EntityStatePart>().EntitiesCapacity;
+			_toCopy = new UnsafeList<Entity>(16);
+			_visited = new UnsafeBitArray(default, entitiesCapacity);
+			_frontier = new UnsafeList<Entity>(16);
+			_map = default;
+		}
+
+		/// <summary>
+		/// Сеет корень в обход. Предусловие (до <see cref="CollectAll"/>): корень должен копироваться, иначе он
+		/// не попадёт в таблицу и <see cref="GetCopy"/> упадёт. Пустой или помеченный IgnoreEntityCopy корень -
+		/// нарушение, ловим явным E.ASSERT в DEBUG.
+		/// </summary>
+		public void AddRoot(Entity root)
+		{
+			E.ASSERT(!root.IsEmpty(), "EntityTreeCopier: root пустой - копировать нечего, нарушено предусловие.");
+			E.ASSERT(!_hasIgnoreSet || !root.Has<IgnoreEntityCopy>(_srcWorld), "EntityTreeCopier: root помечен IgnoreEntityCopy - корень не скопируется, GetCopy упадёт. Нарушено предусловие.");
+			_frontier.Add(root);
+		}
+
+		/// <summary>
+		/// Проход A: обойти поддеревья всех засеянных корней (без повторов через visited), собрать в toCopy.
+		/// </summary>
+		public void CollectAll()
+		{
+			// Реестр компонентов: индекс слота = локальный индекс компонента, по нему идёт диспатч копира.
+			ref var manager = ref _srcWorld.GetComponentsManager();
+
+			while (_frontier.count > 0)
+			{
+				var entity = _frontier.RemoveLast();
+				// Пустая ссылка (необязательная дочерняя сущность не задана) не копируется: иначе для неё
+				// создалась бы лишняя сущность-копия, и перенастройка ссылок вернула бы её вместо Entity.EMPTY.
+				if (entity.IsEmpty())
+				{
+					continue;
+				}
+				if (_visited.IsSet(entity.id))
+				{
+					continue;
+				}
+				_visited.Set(entity.id, true);
+				if (_hasIgnoreSet && entity.Has<IgnoreEntityCopy>(_srcWorld))
+				{
+					continue;
+				}
+
+				_toCopy.Add(entity);
+
+				for (var i = 0; i < manager.Length; i++)
+				{
+					ref var slot = ref manager.GetByIndex(i);
+					if (!slot.IsValid())
+					{
+						continue;
+					}
+					if (!slot.GetPtr(_srcWorld).Value().HasElement(_srcWorld, entity))
+					{
+						continue;
+					}
+					if (GeneratedCopier.IsCopiable(i))
+					{
+						GeneratedCopier.AppendEntities(i, _srcWorld, entity, ref _frontier);
+					}
+				}
+			}
+		}
+
+		/// <summary>
+		/// Проход B: создать все копии, чтобы на проходе C ссылки уже было куда перенастраивать.
+		/// </summary>
+		public void CreateCopies()
+		{
+			_map = new UnsafeDictionary<Entity, Entity>(default, _toCopy.count);
+			foreach (var oldEntity in _toCopy)
+			{
+				var newEntity = CreateEntityCopy(oldEntity);
+				_map.Add(oldEntity, newEntity);
+			}
+		}
+
+		/// <summary>
+		/// Проход C: скопировать значения и перенастроить ссылки по таблице.
+		/// </summary>
+		public void CopyValues()
+		{
+			ref var manager = ref _srcWorld.GetComponentsManager();
+
+			foreach (var oldEntity in _toCopy)
+			{
+				var newEntity = _map[oldEntity];
+
+				for (var i = 0; i < manager.Length; i++)
+				{
+					ref var slot = ref manager.GetByIndex(i);
+					if (!slot.IsValid())
+					{
+						continue;
+					}
+					if (!slot.GetPtr(_srcWorld).Value().HasElement(_srcWorld, oldEntity))
+					{
+						continue;
+					}
+					if (GeneratedCopier.IsCopiable(i))
+					{
+						GeneratedCopier.CopyComponent(i, _srcWorld, _dstWorld, oldEntity, newEntity, in _map);
+					}
+					else if (!GeneratedCopier.IsSkipped(i))
+					{
+						// Ссылочный компонент без маркера ([GenerateCopy]/[ManualCopy]/[SkipCopy]) при копии потеряется.
+						// Сообщаем в код игры: в релизе лог виден, в DEBUG падаем. Список непокрытого - _worklist.txt.
+						GeneratedCopier.ReportUnhandled(i);
+					}
+				}
+			}
+		}
+
+		/// <summary>
+		/// Возвращает копию корня (или любой собранной сущности) после прохода C.
+		/// </summary>
+		public Entity GetCopy(Entity entity)
+		{
+			return _map[entity];
+		}
+
+		public void Dispose()
+		{
+			// Полу-созданные сущности dstWorld не откатываем: throw где-либо в проходах рвёт загрузку этапа,
+			// мир целиком отбрасывается. Чистим только временные буферы обхода.
+			if (_map.IsCreated)
+			{
+				_map.Dispose();
+			}
+			_toCopy.Dispose();
+			_visited.Dispose();
+			_frontier.Dispose();
+		}
+
+		private Entity CreateEntityCopy(Entity oldEntity)
+		{
+#if ENABLE_ENTITY_NAMES
+			ref readonly var name = ref _srcWorld.GetService<EntityStatePart>().GetEntityNameRef(_srcWorld, oldEntity);
+			return _dstWorld.GetService<EntityStatePart>().CreateEntity(_dstWorld, in name);
+#else
+			return _dstWorld.GetService<EntityStatePart>().CreateEntity(_dstWorld);
+#endif
+		}
+	}
+}

--- a/MemoryAllocator/State/Copy/EntityTreeCopier.cs
+++ b/MemoryAllocator/State/Copy/EntityTreeCopier.cs
@@ -31,7 +31,7 @@ namespace Sapientia.MemoryAllocator.State
 			// visited - бит-сет по entity.id (ushort): id всех живых сущностей исходного мира < EntitiesCapacity.
 			var entitiesCapacity = srcWorld.GetService<EntityStatePart>().EntitiesCapacity;
 			_toCopy = new UnsafeList<Entity>(16);
-			_visited = new UnsafeBitArray(default, entitiesCapacity);
+			_visited = new UnsafeBitArray(entitiesCapacity);
 			_frontier = new UnsafeList<Entity>(16);
 			_map = default;
 		}
@@ -101,7 +101,7 @@ namespace Sapientia.MemoryAllocator.State
 		/// </summary>
 		public void CreateCopies()
 		{
-			_map = new UnsafeDictionary<Entity, Entity>(default, _toCopy.count);
+			_map = default;
 			foreach (var oldEntity in _toCopy)
 			{
 				var newEntity = CreateEntityCopy(oldEntity);

--- a/MemoryAllocator/State/Copy/EntityTreeCopier.cs.meta
+++ b/MemoryAllocator/State/Copy/EntityTreeCopier.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 188b3ef69b3b9ce4fa1bbc88fbc1cb87

--- a/MemoryAllocator/State/Copy/GeneratedCopier.cs
+++ b/MemoryAllocator/State/Copy/GeneratedCopier.cs
@@ -29,6 +29,15 @@ namespace Sapientia.MemoryAllocator.State
 		}
 
 		/// <summary>
+		/// Помечен ли <paramref name="typeId"/> как намеренно не копируемый. Если диспатч не зарегистрирован -
+		/// считаем пропущенным (копировать всё равно нечем, ложную диагностику не поднимаем).
+		/// </summary>
+		public static bool IsSkipped(TypeId typeId)
+		{
+			return _copier == null || _copier.IsSkipped(typeId);
+		}
+
+		/// <summary>
 		/// Складывает дочерние сущности компонента <paramref name="typeId"/> с <paramref name="entity"/>
 		/// в <paramref name="frontier"/>. Вызывается только когда <see cref="IsCopiable"/> вернул true.
 		/// </summary>
@@ -44,6 +53,15 @@ namespace Sapientia.MemoryAllocator.State
 		public static void CopyComponent(TypeId typeId, WorldState oldWS, WorldState newWS, Entity oldEntity, Entity newEntity, in UnsafeDictionary<Entity, Entity> map)
 		{
 			_copier!.CopyComponent(typeId, oldWS, newWS, oldEntity, newEntity, in map);
+		}
+
+		/// <summary>
+		/// Сообщает о необработанном ссылочном компоненте через диспатч в код игры. Если диспатч не
+		/// зарегистрирован - сообщать нечем и незачем (копировать всё равно нечем).
+		/// </summary>
+		public static void ReportUnhandled(TypeId typeId)
+		{
+			_copier?.ReportUnhandled(typeId);
 		}
 	}
 }

--- a/MemoryAllocator/State/Copy/GeneratedCopier.cs
+++ b/MemoryAllocator/State/Copy/GeneratedCopier.cs
@@ -23,7 +23,7 @@ namespace Sapientia.MemoryAllocator.State
 		/// <summary>
 		/// Есть ли копир для <paramref name="typeId"/>. false, если диспатч не зарегистрирован.
 		/// </summary>
-		public static bool IsCopiable(TypeId typeId)
+		public static bool IsCopiable(TypeId<IComponent> typeId)
 		{
 			return _copier != null && _copier.IsCopiable(typeId);
 		}
@@ -32,7 +32,7 @@ namespace Sapientia.MemoryAllocator.State
 		/// Помечен ли <paramref name="typeId"/> как намеренно не копируемый. Если диспатч не зарегистрирован -
 		/// считаем пропущенным (копировать всё равно нечем, ложную диагностику не поднимаем).
 		/// </summary>
-		public static bool IsSkipped(TypeId typeId)
+		public static bool IsSkipped(TypeId<IComponent> typeId)
 		{
 			return _copier == null || _copier.IsSkipped(typeId);
 		}
@@ -41,7 +41,7 @@ namespace Sapientia.MemoryAllocator.State
 		/// Складывает дочерние сущности компонента <paramref name="typeId"/> с <paramref name="entity"/>
 		/// в <paramref name="frontier"/>. Вызывается только когда <see cref="IsCopiable"/> вернул true.
 		/// </summary>
-		public static void AppendEntities(TypeId typeId, WorldState world, Entity entity, ref UnsafeList<Entity> frontier)
+		public static void AppendEntities(TypeId<IComponent> typeId, WorldState world, Entity entity, ref UnsafeList<Entity> frontier)
 		{
 			_copier!.AppendEntities(typeId, world, entity, ref frontier);
 		}
@@ -50,7 +50,7 @@ namespace Sapientia.MemoryAllocator.State
 		/// Копирует компонент <paramref name="typeId"/> со старой сущности на новую и перенастраивает
 		/// ссылки по <paramref name="map"/>. Вызывается только когда <see cref="IsCopiable"/> вернул true.
 		/// </summary>
-		public static void CopyComponent(TypeId typeId, WorldState oldWS, WorldState newWS, Entity oldEntity, Entity newEntity, in UnsafeDictionary<Entity, Entity> map)
+		public static void CopyComponent(TypeId<IComponent> typeId, WorldState oldWS, WorldState newWS, Entity oldEntity, Entity newEntity, in UnsafeDictionary<Entity, Entity> map)
 		{
 			_copier!.CopyComponent(typeId, oldWS, newWS, oldEntity, newEntity, in map);
 		}
@@ -59,7 +59,7 @@ namespace Sapientia.MemoryAllocator.State
 		/// Сообщает о необработанном ссылочном компоненте через диспатч в код игры. Если диспатч не
 		/// зарегистрирован - сообщать нечем и незачем (копировать всё равно нечем).
 		/// </summary>
-		public static void ReportUnhandled(TypeId typeId)
+		public static void ReportUnhandled(TypeId<IComponent> typeId)
 		{
 			_copier?.ReportUnhandled(typeId);
 		}

--- a/MemoryAllocator/State/Copy/GeneratedCopier.cs
+++ b/MemoryAllocator/State/Copy/GeneratedCopier.cs
@@ -4,26 +4,37 @@ using Sapientia.TypeIndexer;
 namespace Sapientia.MemoryAllocator.State
 {
 	/// <summary>
-	/// Выбор копира компонента по <see cref="TypeId"/>. Связывает движок в Sapientia с кодом игры,
-	/// который этот выбор заполняет. Пока пусто: копируемых типов нет, поэтому <see cref="AppendEntities"/>
-	/// и <see cref="CopyComponent"/> не вызываются (защищены проверкой <see cref="IsCopiable"/>).
+	/// Выбор копира компонента по <see cref="TypeId"/>. Фасад: сам диспатч живёт в коде игры
+	/// (<see cref="IComponentCopier"/>) и регистрируется через <see cref="SetCopier"/>. Пока копир не
+	/// зарегистрирован, копируемых типов нет.
 	/// </summary>
 	public static class GeneratedCopier
 	{
+		private static IComponentCopier? _copier;
+
 		/// <summary>
-		/// Есть ли копир для <paramref name="typeId"/>. Пока всегда false.
+		/// Регистрирует диспатч из кода игры. Вызывается один раз при старте.
+		/// </summary>
+		public static void SetCopier(IComponentCopier copier)
+		{
+			_copier = copier;
+		}
+
+		/// <summary>
+		/// Есть ли копир для <paramref name="typeId"/>. false, если диспатч не зарегистрирован.
 		/// </summary>
 		public static bool IsCopiable(TypeId typeId)
 		{
-			return false;
+			return _copier != null && _copier.IsCopiable(typeId);
 		}
 
 		/// <summary>
 		/// Складывает дочерние сущности компонента <paramref name="typeId"/> с <paramref name="entity"/>
-		/// в очередь обхода. Вызывается только когда <see cref="IsCopiable"/> вернул true.
+		/// в <paramref name="frontier"/>. Вызывается только когда <see cref="IsCopiable"/> вернул true.
 		/// </summary>
 		public static void AppendEntities(TypeId typeId, WorldState world, Entity entity, ref UnsafeList<Entity> frontier)
 		{
+			_copier!.AppendEntities(typeId, world, entity, ref frontier);
 		}
 
 		/// <summary>
@@ -32,6 +43,7 @@ namespace Sapientia.MemoryAllocator.State
 		/// </summary>
 		public static void CopyComponent(TypeId typeId, WorldState oldWS, WorldState newWS, Entity oldEntity, Entity newEntity, in UnsafeDictionary<Entity, Entity> map)
 		{
+			_copier!.CopyComponent(typeId, oldWS, newWS, oldEntity, newEntity, in map);
 		}
 	}
 }

--- a/MemoryAllocator/State/Copy/GeneratedCopier.cs
+++ b/MemoryAllocator/State/Copy/GeneratedCopier.cs
@@ -1,0 +1,37 @@
+using Sapientia.Collections;
+using Sapientia.TypeIndexer;
+
+namespace Sapientia.MemoryAllocator.State
+{
+	/// <summary>
+	/// Выбор копира компонента по <see cref="TypeId"/>. Связывает движок в Sapientia с кодом игры,
+	/// который этот выбор заполняет. Пока пусто: копируемых типов нет, поэтому <see cref="AppendEntities"/>
+	/// и <see cref="CopyComponent"/> не вызываются (защищены проверкой <see cref="IsCopiable"/>).
+	/// </summary>
+	public static class GeneratedCopier
+	{
+		/// <summary>
+		/// Есть ли копир для <paramref name="typeId"/>. Пока всегда false.
+		/// </summary>
+		public static bool IsCopiable(TypeId typeId)
+		{
+			return false;
+		}
+
+		/// <summary>
+		/// Складывает дочерние сущности компонента <paramref name="typeId"/> с <paramref name="entity"/>
+		/// в очередь обхода. Вызывается только когда <see cref="IsCopiable"/> вернул true.
+		/// </summary>
+		public static void AppendEntities(TypeId typeId, WorldState world, Entity entity, ref UnsafeList<Entity> frontier)
+		{
+		}
+
+		/// <summary>
+		/// Копирует компонент <paramref name="typeId"/> со старой сущности на новую и перенастраивает
+		/// ссылки по <paramref name="map"/>. Вызывается только когда <see cref="IsCopiable"/> вернул true.
+		/// </summary>
+		public static void CopyComponent(TypeId typeId, WorldState oldWS, WorldState newWS, Entity oldEntity, Entity newEntity, in UnsafeDictionary<Entity, Entity> map)
+		{
+		}
+	}
+}

--- a/MemoryAllocator/State/Copy/GeneratedCopier.cs.meta
+++ b/MemoryAllocator/State/Copy/GeneratedCopier.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 98e4c33682aa15840b07e1ba5a8077d9

--- a/MemoryAllocator/State/Copy/IComponentCopier.cs
+++ b/MemoryAllocator/State/Copy/IComponentCopier.cs
@@ -4,38 +4,39 @@ using Sapientia.TypeIndexer;
 namespace Sapientia.MemoryAllocator.State
 {
 	/// <summary>
-	/// Реализация выбора копира по <see cref="TypeId"/>. Живёт в коде игры (пишется вручную или генератором),
-	/// регистрируется в <see cref="GeneratedCopier"/>. Нужна потому, что движок в Sapientia не видит типы игры.
+	/// Диспатч копира по локальному индексу компонента (<see cref="TypeId{IComponent}"/>). Реализация
+	/// (<see cref="ComponentCopier"/>) запекается генератором и регистрируется в <see cref="GeneratedCopier"/>.
+	/// Лог о необработанном компоненте делегируется в код игры, т.к. движок в Sapientia не видит WLog.
 	/// </summary>
 	public interface IComponentCopier
 	{
 		/// <summary>
 		/// Есть ли копир для <paramref name="typeId"/>.
 		/// </summary>
-		bool IsCopiable(TypeId typeId);
+		bool IsCopiable(TypeId<IComponent> typeId);
 
 		/// <summary>
 		/// Помечен ли <paramref name="typeId"/> как намеренно не копируемый (<see cref="SkipCopyAttribute"/>).
 		/// Нужно, чтобы отличить ожидаемый пропуск от необработанного ссылочного компонента (молчаливая потеря).
 		/// </summary>
-		bool IsSkipped(TypeId typeId);
+		bool IsSkipped(TypeId<IComponent> typeId);
 
 		/// <summary>
 		/// Складывает дочерние сущности компонента <paramref name="typeId"/> с <paramref name="entity"/>
 		/// в очередь обхода.
 		/// </summary>
-		void AppendEntities(TypeId typeId, WorldState world, Entity entity, ref UnsafeList<Entity> frontier);
+		void AppendEntities(TypeId<IComponent> typeId, WorldState world, Entity entity, ref UnsafeList<Entity> frontier);
 
 		/// <summary>
 		/// Копирует компонент <paramref name="typeId"/> со старой сущности на новую и перенастраивает
 		/// ссылки по <paramref name="map"/>.
 		/// </summary>
-		void CopyComponent(TypeId typeId, WorldState oldWS, WorldState newWS, Entity oldEntity, Entity newEntity, in UnsafeDictionary<Entity, Entity> map);
+		void CopyComponent(TypeId<IComponent> typeId, WorldState oldWS, WorldState newWS, Entity oldEntity, Entity newEntity, in UnsafeDictionary<Entity, Entity> map);
 
 		/// <summary>
 		/// Сообщает о необработанном ссылочном компоненте (без маркера копирования). Реализация в коде игры
 		/// пишет ошибку в лог (видно в релизе) и роняет в DEBUG, чтобы потеря при копии не прошла молча.
 		/// </summary>
-		void ReportUnhandled(TypeId typeId);
+		void ReportUnhandled(TypeId<IComponent> typeId);
 	}
 }

--- a/MemoryAllocator/State/Copy/IComponentCopier.cs
+++ b/MemoryAllocator/State/Copy/IComponentCopier.cs
@@ -1,0 +1,29 @@
+using Sapientia.Collections;
+using Sapientia.TypeIndexer;
+
+namespace Sapientia.MemoryAllocator.State
+{
+	/// <summary>
+	/// Реализация выбора копира по <see cref="TypeId"/>. Живёт в коде игры (пишется вручную или генератором),
+	/// регистрируется в <see cref="GeneratedCopier"/>. Нужна потому, что движок в Sapientia не видит типы игры.
+	/// </summary>
+	public interface IComponentCopier
+	{
+		/// <summary>
+		/// Есть ли копир для <paramref name="typeId"/>.
+		/// </summary>
+		bool IsCopiable(TypeId typeId);
+
+		/// <summary>
+		/// Складывает дочерние сущности компонента <paramref name="typeId"/> с <paramref name="entity"/>
+		/// в очередь обхода.
+		/// </summary>
+		void AppendEntities(TypeId typeId, WorldState world, Entity entity, ref UnsafeList<Entity> frontier);
+
+		/// <summary>
+		/// Копирует компонент <paramref name="typeId"/> со старой сущности на новую и перенастраивает
+		/// ссылки по <paramref name="map"/>.
+		/// </summary>
+		void CopyComponent(TypeId typeId, WorldState oldWS, WorldState newWS, Entity oldEntity, Entity newEntity, in UnsafeDictionary<Entity, Entity> map);
+	}
+}

--- a/MemoryAllocator/State/Copy/IComponentCopier.cs
+++ b/MemoryAllocator/State/Copy/IComponentCopier.cs
@@ -15,6 +15,12 @@ namespace Sapientia.MemoryAllocator.State
 		bool IsCopiable(TypeId typeId);
 
 		/// <summary>
+		/// Помечен ли <paramref name="typeId"/> как намеренно не копируемый (<see cref="SkipCopyAttribute"/>).
+		/// Нужно, чтобы отличить ожидаемый пропуск от необработанного ссылочного компонента (молчаливая потеря).
+		/// </summary>
+		bool IsSkipped(TypeId typeId);
+
+		/// <summary>
 		/// Складывает дочерние сущности компонента <paramref name="typeId"/> с <paramref name="entity"/>
 		/// в очередь обхода.
 		/// </summary>
@@ -25,5 +31,11 @@ namespace Sapientia.MemoryAllocator.State
 		/// ссылки по <paramref name="map"/>.
 		/// </summary>
 		void CopyComponent(TypeId typeId, WorldState oldWS, WorldState newWS, Entity oldEntity, Entity newEntity, in UnsafeDictionary<Entity, Entity> map);
+
+		/// <summary>
+		/// Сообщает о необработанном ссылочном компоненте (без маркера копирования). Реализация в коде игры
+		/// пишет ошибку в лог (видно в релизе) и роняет в DEBUG, чтобы потеря при копии не прошла молча.
+		/// </summary>
+		void ReportUnhandled(TypeId typeId);
 	}
 }

--- a/MemoryAllocator/State/Copy/IComponentCopier.cs.meta
+++ b/MemoryAllocator/State/Copy/IComponentCopier.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 717da49a90550d04d80d0ff47a5b14f7

--- a/MemoryAllocator/State/Copy/ICopiable.cs
+++ b/MemoryAllocator/State/Copy/ICopiable.cs
@@ -1,0 +1,25 @@
+using Sapientia.Collections;
+
+namespace Sapientia.MemoryAllocator.State
+{
+	/// <summary>
+	/// Компонент, который умеет копировать сам себя в другой мир. Реализацию пишет генератор или
+	/// человек (для сложных структур с перекрытием полей).
+	/// </summary>
+	public interface ICopiable<T> where T : unmanaged, IComponent, ICopiable<T>
+	{
+		/// <summary>
+		/// this - компонент в исходном мире. Положить в <paramref name="entities"/> только свои дочерние
+		/// сущности. Ссылки на чужие сущности не класть - их перенастроит <see cref="InnerCopy"/>.
+		/// </summary>
+		void AppendEntities(WorldState world, ref UnsafeList<Entity> entities);
+
+		/// <summary>
+		/// this - старый компонент. <paramref name="component"/> - его копия в новом мире: простые поля
+		/// уже верны, поля-сущности держат старые значения, коллекции ссылаются на старую память.
+		/// Перенастроить поля-сущности по <paramref name="map"/>, коллекции пересоздать в новом мире по
+		/// одному элементу. Если сущности нет в <paramref name="map"/> - поставить <see cref="Entity.EMPTY"/>.
+		/// </summary>
+		void InnerCopy(WorldState oldWS, WorldState newWS, ref T component, in UnsafeDictionary<Entity, Entity> map);
+	}
+}

--- a/MemoryAllocator/State/Copy/ICopiable.cs.meta
+++ b/MemoryAllocator/State/Copy/ICopiable.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 45eb5b8479f76234891cf697145a8a48

--- a/MemoryAllocator/State/Copy/WorldStateCopyExtensions.cs
+++ b/MemoryAllocator/State/Copy/WorldStateCopyExtensions.cs
@@ -15,19 +15,12 @@ namespace Sapientia.MemoryAllocator.State
 		/// </summary>
 		public static Entity CopyEntityTree(this WorldState srcWorld, Entity root, WorldState dstWorld)
 		{
-			var copier = new EntityTreeCopier(srcWorld, dstWorld);
-			try
-			{
-				copier.AddRoot(root);
-				copier.CollectAll();
-				copier.CreateCopies();
-				copier.CopyValues();
-				return copier.GetCopy(root);
-			}
-			finally
-			{
-				copier.Dispose();
-			}
+			using var copier = new EntityTreeCopier(srcWorld, dstWorld);
+			copier.AddRoot(root);
+			copier.CollectAll();
+			copier.CreateCopies();
+			copier.CopyValues();
+			return copier.GetCopy(root);
 		}
 
 		/// <summary>
@@ -39,34 +32,18 @@ namespace Sapientia.MemoryAllocator.State
 		{
 			E.ASSERT(newRoots.Length >= roots.Length, "CopyEntityTreeBatch: newRoots короче roots - некуда писать копии корней.");
 
-			var copier = new EntityTreeCopier(srcWorld, dstWorld);
-			try
+			using var copier = new EntityTreeCopier(srcWorld, dstWorld);
+			foreach (var root in roots)
 			{
-				foreach (var root in roots)
-				{
-					copier.AddRoot(root);
-				}
-				copier.CollectAll();
-				copier.CreateCopies();
-				copier.CopyValues();
-				for (var i = 0; i < roots.Length; i++)
-				{
-					newRoots[i] = copier.GetCopy(roots[i]);
-				}
+				copier.AddRoot(root);
 			}
-			finally
+			copier.CollectAll();
+			copier.CreateCopies();
+			copier.CopyValues();
+			for (var i = 0; i < roots.Length; i++)
 			{
-				copier.Dispose();
+				newRoots[i] = copier.GetCopy(roots[i]);
 			}
-		}
-
-		/// <summary>
-		/// Переводит старую сущность в новую по таблице копирования. Если сущности нет в таблице (ссылка
-		/// на чужую сущность, которую не копировали) - возвращает <see cref="Entity.EMPTY"/>.
-		/// </summary>
-		public static Entity Remap(this in UnsafeDictionary<Entity, Entity> map, Entity entity)
-		{
-			return map.TryGetValue(entity, out var mapped) ? mapped : Entity.EMPTY;
 		}
 
 		/// <summary>

--- a/MemoryAllocator/State/Copy/WorldStateCopyExtensions.cs
+++ b/MemoryAllocator/State/Copy/WorldStateCopyExtensions.cs
@@ -19,78 +19,98 @@ namespace Sapientia.MemoryAllocator.State
 		/// </summary>
 		public static Entity CopyEntityTree(this WorldState srcWorld, Entity root, WorldState dstWorld)
 		{
+			// Набор для метки может быть не зарегистрирован; тогда метки нет ни на одной сущности.
+			var hasIgnoreSet = srcWorld.HasComponentSet<IgnoreEntityCopy>();
+
+			// Предусловие (до аллокаций): корень должен копироваться. Пустой или помеченный IgnoreEntityCopy
+			// корень не попадёт в map, и map[root] упал бы KeyNotFound - проверяем явным E.ASSERT в DEBUG.
+			E.ASSERT(!root.IsEmpty(), "CopyEntityTree: root пустой - копировать нечего, нарушено предусловие.");
+			E.ASSERT(!hasIgnoreSet || !root.Has<IgnoreEntityCopy>(srcWorld), "CopyEntityTree: root помечен IgnoreEntityCopy - корень не скопируется, map[root] упадёт. Нарушено предусловие.");
+
 			var toCopy = new UnsafeList<Entity>(default, 16);
 			var visited = new UnsafeHashSet<Entity>(default, 16);
 			var frontier = new UnsafeList<Entity>(default, 16);
 			var typeIds = new List<TypeId>();
+			var map = default(UnsafeDictionary<Entity, Entity>);
 
-			// Набор для метки может быть не зарегистрирован; тогда метки нет ни на одной сущности.
-			var hasIgnoreSet = srcWorld.HasComponentSet<IgnoreEntityCopy>();
-
-			frontier.Add(root);
-
-			// Проход A: собрать поддерево (обход, без повторов через visited).
-			while (frontier.count > 0)
+			try
 			{
-				var entity = frontier.RemoveLast();
-				// Пустая ссылка (необязательная дочерняя сущность не задана) не копируется: иначе для неё
-				// создалась бы лишняя сущность-копия, и перенастройка ссылок вернула бы её вместо Entity.EMPTY.
-				if (entity.IsEmpty())
-				{
-					continue;
-				}
-				if (!visited.Add(entity))
-				{
-					continue;
-				}
-				if (hasIgnoreSet && entity.Has<IgnoreEntityCopy>(srcWorld))
-				{
-					continue;
-				}
+				frontier.Add(root);
 
-				toCopy.Add(entity);
-
-				srcWorld.CollectComponentTypeIds(entity, typeIds);
-				foreach (var typeId in typeIds)
+				// Проход A: собрать поддерево (обход, без повторов через visited).
+				while (frontier.count > 0)
 				{
-					if (GeneratedCopier.IsCopiable(typeId))
+					var entity = frontier.RemoveLast();
+					// Пустая ссылка (необязательная дочерняя сущность не задана) не копируется: иначе для неё
+					// создалась бы лишняя сущность-копия, и перенастройка ссылок вернула бы её вместо Entity.EMPTY.
+					if (entity.IsEmpty())
 					{
-						GeneratedCopier.AppendEntities(typeId, srcWorld, entity, ref frontier);
+						continue;
+					}
+					if (!visited.Add(entity))
+					{
+						continue;
+					}
+					if (hasIgnoreSet && entity.Has<IgnoreEntityCopy>(srcWorld))
+					{
+						continue;
+					}
+
+					toCopy.Add(entity);
+
+					srcWorld.CollectComponentTypeIds(entity, typeIds);
+					foreach (var typeId in typeIds)
+					{
+						if (GeneratedCopier.IsCopiable(typeId))
+						{
+							GeneratedCopier.AppendEntities(typeId, srcWorld, entity, ref frontier);
+						}
 					}
 				}
-			}
 
-			// Проход B: создать все копии, чтобы на проходе C ссылки уже было куда перенастраивать.
-			var map = new UnsafeDictionary<Entity, Entity>(default, toCopy.count);
-			foreach (var oldEntity in toCopy)
-			{
-				var newEntity = CreateEntityCopy(srcWorld, dstWorld, oldEntity);
-				map.Add(oldEntity, newEntity);
-			}
-
-			// Проход C: скопировать значения и перенастроить ссылки по таблице.
-			foreach (var oldEntity in toCopy)
-			{
-				var newEntity = map[oldEntity];
-
-				srcWorld.CollectComponentTypeIds(oldEntity, typeIds);
-				foreach (var typeId in typeIds)
+				// Проход B: создать все копии, чтобы на проходе C ссылки уже было куда перенастраивать.
+				map = new UnsafeDictionary<Entity, Entity>(default, toCopy.count);
+				foreach (var oldEntity in toCopy)
 				{
-					if (GeneratedCopier.IsCopiable(typeId))
+					var newEntity = CreateEntityCopy(srcWorld, dstWorld, oldEntity);
+					map.Add(oldEntity, newEntity);
+				}
+
+				// Проход C: скопировать значения и перенастроить ссылки по таблице.
+				foreach (var oldEntity in toCopy)
+				{
+					var newEntity = map[oldEntity];
+
+					srcWorld.CollectComponentTypeIds(oldEntity, typeIds);
+					foreach (var typeId in typeIds)
 					{
-						GeneratedCopier.CopyComponent(typeId, srcWorld, dstWorld, oldEntity, newEntity, in map);
+						if (GeneratedCopier.IsCopiable(typeId))
+						{
+							GeneratedCopier.CopyComponent(typeId, srcWorld, dstWorld, oldEntity, newEntity, in map);
+						}
+						else if (!GeneratedCopier.IsSkipped(typeId))
+						{
+							// Ссылочный компонент без маркера ([GenerateCopy]/[ManualCopy]/[SkipCopy]) при копии потеряется.
+							// Сообщаем в код игры: в релизе лог виден, в DEBUG падаем. Список непокрытого - _worklist.txt.
+							GeneratedCopier.ReportUnhandled(typeId);
+						}
 					}
 				}
+
+				return map[root];
 			}
-
-			var result = map[root];
-
-			map.Dispose();
-			toCopy.Dispose();
-			visited.Dispose();
-			frontier.Dispose();
-
-			return result;
+			finally
+			{
+				// Чистим временные буферы обхода. Полу-созданные сущности dstWorld не откатываем: throw здесь
+				// рвёт загрузку этапа, мир целиком отбрасывается.
+				if (map.IsCreated)
+				{
+					map.Dispose();
+				}
+				toCopy.Dispose();
+				visited.Dispose();
+				frontier.Dispose();
+			}
 		}
 
 		/// <summary>

--- a/MemoryAllocator/State/Copy/WorldStateCopyExtensions.cs
+++ b/MemoryAllocator/State/Copy/WorldStateCopyExtensions.cs
@@ -1,0 +1,114 @@
+using System.Collections.Generic;
+using Sapientia.Collections;
+using Sapientia.TypeIndexer;
+
+namespace Sapientia.MemoryAllocator.State
+{
+	/// <summary>
+	/// Копирует сущность вместе с её дочерним поддеревом в другой мир (один раз, при переходе между
+	/// этапами). Три прохода: собрать поддерево; создать все копии и запомнить пары старая-новая;
+	/// скопировать значения и перенастроить ссылки. Три, а не два, потому что для перенастройки ссылки
+	/// новая сущность уже должна существовать, поэтому создание идёт до копирования.
+	/// </summary>
+	public static class WorldStateCopyExtensions
+	{
+		/// <summary>
+		/// Копирует <paramref name="root"/> с дочерним поддеревом из srcWorld в dstWorld, возвращает новый
+		/// корень. Условие: dstWorld уже построен (наборы компонентов зарегистрированы), а
+		/// <paramref name="root"/> не помечен <see cref="IgnoreEntityCopy"/>.
+		/// </summary>
+		public static Entity CopyEntityTree(this WorldState srcWorld, Entity root, WorldState dstWorld)
+		{
+			var toCopy = new UnsafeList<Entity>(default, 16);
+			var visited = new UnsafeHashSet<Entity>(default, 16);
+			var frontier = new UnsafeList<Entity>(default, 16);
+			var typeIds = new List<TypeId>();
+
+			// Набор для метки может быть не зарегистрирован; тогда метки нет ни на одной сущности.
+			var hasIgnoreSet = srcWorld.HasComponentSet<IgnoreEntityCopy>();
+
+			frontier.Add(root);
+
+			// Проход A: собрать поддерево (обход, без повторов через visited).
+			while (frontier.count > 0)
+			{
+				var entity = frontier.RemoveLast();
+				if (!visited.Add(entity))
+				{
+					continue;
+				}
+				if (hasIgnoreSet && entity.Has<IgnoreEntityCopy>(srcWorld))
+				{
+					continue;
+				}
+
+				toCopy.Add(entity);
+
+				srcWorld.CollectComponentTypeIds(entity, typeIds);
+				foreach (var typeId in typeIds)
+				{
+					if (GeneratedCopier.IsCopiable(typeId))
+					{
+						GeneratedCopier.AppendEntities(typeId, srcWorld, entity, ref frontier);
+					}
+				}
+			}
+
+			// Проход B: создать все копии, чтобы на проходе C ссылки уже было куда перенастраивать.
+			var map = new UnsafeDictionary<Entity, Entity>(default, toCopy.count);
+			foreach (var oldEntity in toCopy)
+			{
+				var newEntity = CreateEntityCopy(srcWorld, dstWorld, oldEntity);
+				map.Add(oldEntity, newEntity);
+			}
+
+			// Проход C: скопировать значения и перенастроить ссылки по таблице.
+			foreach (var oldEntity in toCopy)
+			{
+				var newEntity = map[oldEntity];
+
+				srcWorld.CollectComponentTypeIds(oldEntity, typeIds);
+				foreach (var typeId in typeIds)
+				{
+					if (GeneratedCopier.IsCopiable(typeId))
+					{
+						GeneratedCopier.CopyComponent(typeId, srcWorld, dstWorld, oldEntity, newEntity, in map);
+					}
+				}
+			}
+
+			var result = map[root];
+
+			map.Dispose();
+			toCopy.Dispose();
+			visited.Dispose();
+			frontier.Dispose();
+
+			return result;
+		}
+
+		/// <summary>
+		/// Читает компонент <typeparamref name="T"/> из старого мира, делает копию значения и
+		/// перенастраивает ссылки через <see cref="ICopiable{T}.InnerCopy"/>. Возвращает копию для записи
+		/// в новый мир.
+		/// </summary>
+		public static T Copy<T>(this WorldState oldWS, Entity entity, WorldState newWS, in UnsafeDictionary<Entity, Entity> map)
+			where T : unmanaged, IComponent, ICopiable<T>
+		{
+			var oldComponent = new ComponentSetContext<T>(oldWS).ReadElement(entity);
+			var newComponent = oldComponent;
+			oldComponent.InnerCopy(oldWS, newWS, ref newComponent, in map);
+			return newComponent;
+		}
+
+		private static Entity CreateEntityCopy(WorldState srcWorld, WorldState dstWorld, Entity oldEntity)
+		{
+#if ENABLE_ENTITY_NAMES
+			var name = srcWorld.GetService<EntityStatePart>().GetEntityName(srcWorld, oldEntity);
+			return dstWorld.GetService<EntityStatePart>().CreateEntity(dstWorld, name);
+#else
+			return dstWorld.GetService<EntityStatePart>().CreateEntity(dstWorld);
+#endif
+		}
+	}
+}

--- a/MemoryAllocator/State/Copy/WorldStateCopyExtensions.cs
+++ b/MemoryAllocator/State/Copy/WorldStateCopyExtensions.cs
@@ -1,115 +1,62 @@
-using System.Collections.Generic;
+using System;
 using Sapientia.Collections;
-using Sapientia.TypeIndexer;
 
 namespace Sapientia.MemoryAllocator.State
 {
 	/// <summary>
-	/// Копирует сущность вместе с её дочерним поддеревом в другой мир (один раз, при переходе между
-	/// этапами). Три прохода: собрать поддерево; создать все копии и запомнить пары старая-новая;
-	/// скопировать значения и перенастроить ссылки. Три, а не два, потому что для перенастройки ссылки
-	/// новая сущность уже должна существовать, поэтому создание идёт до копирования.
+	/// Точки входа копирования сущностей между мирами. Сам обход и буферы живут в <see cref="EntityTreeCopier"/>.
 	/// </summary>
 	public static class WorldStateCopyExtensions
 	{
 		/// <summary>
 		/// Копирует <paramref name="root"/> с дочерним поддеревом из srcWorld в dstWorld, возвращает новый
-		/// корень. Условие: dstWorld уже построен (наборы компонентов зарегистрированы), а
-		/// <paramref name="root"/> не помечен <see cref="IgnoreEntityCopy"/>.
+		/// корень. Тонкая обёртка над <see cref="EntityTreeCopier"/> на один корень. Условие: dstWorld построен
+		/// (наборы компонентов зарегистрированы), <paramref name="root"/> не помечен <see cref="IgnoreEntityCopy"/>.
 		/// </summary>
 		public static Entity CopyEntityTree(this WorldState srcWorld, Entity root, WorldState dstWorld)
 		{
-			// Набор для метки может быть не зарегистрирован; тогда метки нет ни на одной сущности.
-			var hasIgnoreSet = srcWorld.HasComponentSet<IgnoreEntityCopy>();
-
-			// Предусловие (до аллокаций): корень должен копироваться. Пустой или помеченный IgnoreEntityCopy
-			// корень не попадёт в map, и map[root] упал бы KeyNotFound - проверяем явным E.ASSERT в DEBUG.
-			E.ASSERT(!root.IsEmpty(), "CopyEntityTree: root пустой - копировать нечего, нарушено предусловие.");
-			E.ASSERT(!hasIgnoreSet || !root.Has<IgnoreEntityCopy>(srcWorld), "CopyEntityTree: root помечен IgnoreEntityCopy - корень не скопируется, map[root] упадёт. Нарушено предусловие.");
-
-			var toCopy = new UnsafeList<Entity>(default, 16);
-			var visited = new UnsafeHashSet<Entity>(default, 16);
-			var frontier = new UnsafeList<Entity>(default, 16);
-			var typeIds = new List<TypeId>();
-			var map = default(UnsafeDictionary<Entity, Entity>);
-
+			var copier = new EntityTreeCopier(srcWorld, dstWorld);
 			try
 			{
-				frontier.Add(root);
-
-				// Проход A: собрать поддерево (обход, без повторов через visited).
-				while (frontier.count > 0)
-				{
-					var entity = frontier.RemoveLast();
-					// Пустая ссылка (необязательная дочерняя сущность не задана) не копируется: иначе для неё
-					// создалась бы лишняя сущность-копия, и перенастройка ссылок вернула бы её вместо Entity.EMPTY.
-					if (entity.IsEmpty())
-					{
-						continue;
-					}
-					if (!visited.Add(entity))
-					{
-						continue;
-					}
-					if (hasIgnoreSet && entity.Has<IgnoreEntityCopy>(srcWorld))
-					{
-						continue;
-					}
-
-					toCopy.Add(entity);
-
-					srcWorld.CollectComponentTypeIds(entity, typeIds);
-					foreach (var typeId in typeIds)
-					{
-						if (GeneratedCopier.IsCopiable(typeId))
-						{
-							GeneratedCopier.AppendEntities(typeId, srcWorld, entity, ref frontier);
-						}
-					}
-				}
-
-				// Проход B: создать все копии, чтобы на проходе C ссылки уже было куда перенастраивать.
-				map = new UnsafeDictionary<Entity, Entity>(default, toCopy.count);
-				foreach (var oldEntity in toCopy)
-				{
-					var newEntity = CreateEntityCopy(srcWorld, dstWorld, oldEntity);
-					map.Add(oldEntity, newEntity);
-				}
-
-				// Проход C: скопировать значения и перенастроить ссылки по таблице.
-				foreach (var oldEntity in toCopy)
-				{
-					var newEntity = map[oldEntity];
-
-					srcWorld.CollectComponentTypeIds(oldEntity, typeIds);
-					foreach (var typeId in typeIds)
-					{
-						if (GeneratedCopier.IsCopiable(typeId))
-						{
-							GeneratedCopier.CopyComponent(typeId, srcWorld, dstWorld, oldEntity, newEntity, in map);
-						}
-						else if (!GeneratedCopier.IsSkipped(typeId))
-						{
-							// Ссылочный компонент без маркера ([GenerateCopy]/[ManualCopy]/[SkipCopy]) при копии потеряется.
-							// Сообщаем в код игры: в релизе лог виден, в DEBUG падаем. Список непокрытого - _worklist.txt.
-							GeneratedCopier.ReportUnhandled(typeId);
-						}
-					}
-				}
-
-				return map[root];
+				copier.AddRoot(root);
+				copier.CollectAll();
+				copier.CreateCopies();
+				copier.CopyValues();
+				return copier.GetCopy(root);
 			}
 			finally
 			{
-				// Чистим временные буферы обхода. Полу-созданные сущности dstWorld не откатываем: throw здесь
-				// рвёт загрузку этапа, мир целиком отбрасывается.
-				if (map.IsCreated)
+				copier.Dispose();
+			}
+		}
+
+		/// <summary>
+		/// Копирует поддеревья всех <paramref name="roots"/> за один батч: общая таблица копий, поэтому ссылки
+		/// между поддеревьями перенастраиваются корректно. <paramref name="newRoots"/> заполняется копиями корней
+		/// в том же порядке. Условие: каждый корень построен и не помечен <see cref="IgnoreEntityCopy"/>.
+		/// </summary>
+		public static void CopyEntityTreeBatch(this WorldState srcWorld, ReadOnlySpan<Entity> roots, Span<Entity> newRoots, WorldState dstWorld)
+		{
+			E.ASSERT(newRoots.Length >= roots.Length, "CopyEntityTreeBatch: newRoots короче roots - некуда писать копии корней.");
+
+			var copier = new EntityTreeCopier(srcWorld, dstWorld);
+			try
+			{
+				foreach (var root in roots)
 				{
-					map.Dispose();
+					copier.AddRoot(root);
 				}
-				toCopy.Dispose();
-				visited.Dispose();
-				frontier.Dispose();
+				copier.CollectAll();
+				copier.CreateCopies();
+				copier.CopyValues();
+				for (var i = 0; i < roots.Length; i++)
+				{
+					newRoots[i] = copier.GetCopy(roots[i]);
+				}
+			}
+			finally
+			{
+				copier.Dispose();
 			}
 		}
 
@@ -134,16 +81,6 @@ namespace Sapientia.MemoryAllocator.State
 			var newComponent = oldComponent;
 			oldComponent.InnerCopy(oldWS, newWS, ref newComponent, in map);
 			return newComponent;
-		}
-
-		private static Entity CreateEntityCopy(WorldState srcWorld, WorldState dstWorld, Entity oldEntity)
-		{
-#if ENABLE_ENTITY_NAMES
-			var name = srcWorld.GetService<EntityStatePart>().GetEntityName(srcWorld, oldEntity);
-			return dstWorld.GetService<EntityStatePart>().CreateEntity(dstWorld, name);
-#else
-			return dstWorld.GetService<EntityStatePart>().CreateEntity(dstWorld);
-#endif
 		}
 	}
 }

--- a/MemoryAllocator/State/Copy/WorldStateCopyExtensions.cs
+++ b/MemoryAllocator/State/Copy/WorldStateCopyExtensions.cs
@@ -33,6 +33,12 @@ namespace Sapientia.MemoryAllocator.State
 			while (frontier.count > 0)
 			{
 				var entity = frontier.RemoveLast();
+				// Пустая ссылка (необязательная дочерняя сущность не задана) не копируется: иначе для неё
+				// создалась бы лишняя сущность-копия, и перенастройка ссылок вернула бы её вместо Entity.EMPTY.
+				if (entity.IsEmpty())
+				{
+					continue;
+				}
 				if (!visited.Add(entity))
 				{
 					continue;

--- a/MemoryAllocator/State/Copy/WorldStateCopyExtensions.cs
+++ b/MemoryAllocator/State/Copy/WorldStateCopyExtensions.cs
@@ -88,6 +88,15 @@ namespace Sapientia.MemoryAllocator.State
 		}
 
 		/// <summary>
+		/// Переводит старую сущность в новую по таблице копирования. Если сущности нет в таблице (ссылка
+		/// на чужую сущность, которую не копировали) - возвращает <see cref="Entity.EMPTY"/>.
+		/// </summary>
+		public static Entity Remap(this in UnsafeDictionary<Entity, Entity> map, Entity entity)
+		{
+			return map.TryGetValue(entity, out var mapped) ? mapped : Entity.EMPTY;
+		}
+
+		/// <summary>
 		/// Читает компонент <typeparamref name="T"/> из старого мира, делает копию значения и
 		/// перенастраивает ссылки через <see cref="ICopiable{T}.InnerCopy"/>. Возвращает копию для записи
 		/// в новый мир.

--- a/MemoryAllocator/State/Copy/WorldStateCopyExtensions.cs.meta
+++ b/MemoryAllocator/State/Copy/WorldStateCopyExtensions.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 83aefedb3e81e9348828bb65e7b21df1

--- a/MemoryAllocator/State/StateParts/Destroy/State/Components/Activeness/ActivityCallbackComponent.cs
+++ b/MemoryAllocator/State/StateParts/Destroy/State/Components/Activeness/ActivityCallbackComponent.cs
@@ -12,6 +12,8 @@ namespace Sapientia.MemoryAllocator.State
 		public void OnEntityDisabled(WorldState worldState, Entity callbackReceiver);
 	}
 
+	// [SkipCopy]: колбэки активности (Callback-прокси) в другой мир не переносятся.
+	[SkipCopy]
 	public struct ActivityCallbackComponent : IComponent
 	{
 		/// <summary>

--- a/MemoryAllocator/State/StateParts/Destroy/State/Components/Activeness/DisabledComponent.cs
+++ b/MemoryAllocator/State/StateParts/Destroy/State/Components/Activeness/DisabledComponent.cs
@@ -1,5 +1,6 @@
 namespace Sapientia.MemoryAllocator.State
 {
+	[SkipCopy]
 	public struct DisabledComponent : IComponent
 	{
 	}

--- a/MemoryAllocator/State/StateParts/Destroy/State/Components/Destroy/DestroyRequest.cs
+++ b/MemoryAllocator/State/StateParts/Destroy/State/Components/Destroy/DestroyRequest.cs
@@ -1,4 +1,5 @@
 namespace Sapientia.MemoryAllocator.State
 {
+	[SkipCopy]
 	public struct DestroyRequest : IComponent {}
 }

--- a/MemoryAllocator/State/StateParts/Destroy/State/Components/Kill/DelayKillRequest.cs
+++ b/MemoryAllocator/State/StateParts/Destroy/State/Components/Kill/DelayKillRequest.cs
@@ -1,5 +1,6 @@
 namespace Sapientia.MemoryAllocator.State
 {
+	[SkipCopy]
 	public struct DelayKillRequest : IComponent
 	{
 		public float delay;

--- a/MemoryAllocator/State/StateParts/Destroy/State/Components/Kill/KillCallbackComponent.cs
+++ b/MemoryAllocator/State/StateParts/Destroy/State/Components/Kill/KillCallbackComponent.cs
@@ -7,6 +7,9 @@ namespace Sapientia.MemoryAllocator.State
 		public void OnEntityKilled(WorldState worldState, Entity callbackReceiver);
 	}
 
+	// [SkipCopy]: children/parents - внешние связи смерти (на персонажа и источник), их заново ставит
+	// наложение эффекта; killCallbacks - прокси, в другой мир не переносятся.
+	[SkipCopy]
 	public struct KillCallbackComponent : IComponent
 	{
 		public MemList<Entity> children;

--- a/MemoryAllocator/State/StateParts/Destroy/State/Components/Kill/KillRequest.cs
+++ b/MemoryAllocator/State/StateParts/Destroy/State/Components/Kill/KillRequest.cs
@@ -1,4 +1,5 @@
 namespace Sapientia.MemoryAllocator.State
 {
+	[SkipCopy]
 	public struct KillRequest : IComponent {}
 }

--- a/MemoryAllocator/State/StateParts/Entity/EntityStatePart.cs
+++ b/MemoryAllocator/State/StateParts/Entity/EntityStatePart.cs
@@ -38,6 +38,16 @@ namespace Sapientia.MemoryAllocator.State
 				return "[Destroyed]";
 			return entityIdToName[worldState, entity.id].ToString();
 		}
+
+		/// <summary>
+		/// Имя сущности без конвертации в string (индексер MemArray даёт ref). Для копирования имени между
+		/// мирами без round-trip FixedString-string-FixedString. Сущность должна быть живой.
+		/// </summary>
+		public ref readonly FixedString64Bytes GetEntityNameRef(WorldState worldState, in Entity entity)
+		{
+			E.ASSERT(IsEntityExist(worldState, entity), "GetEntityNameRef: сущность уже уничтожена.");
+			return ref entityIdToName[worldState, entity.id];
+		}
 #endif
 
 		public EntityStatePart(int entitiesCapacity, int expandStep = 512)

--- a/MemoryAllocator/State/World/WorldState/WorldState.ServiceRegistry.cs
+++ b/MemoryAllocator/State/World/WorldState/WorldState.ServiceRegistry.cs
@@ -322,11 +322,13 @@ namespace Sapientia.MemoryAllocator
 			=> worldState.GetComponentsManager().Get<T>().IsValid();
 
 		/// <summary>
-		/// Собирает глобальные <see cref="TypeId"/> всех компонентов, присутствующих на <paramref name="entity"/>:
-		/// перебор всех зарегистрированных <see cref="ComponentSet"/>'ов с проверкой <see cref="ComponentSet.HasElement(WorldState, Entity)"/>.
+		/// Собирает локальные индексы (<see cref="TypeId{IComponent}"/>) всех компонентов, присутствующих на
+		/// <paramref name="entity"/>: перебор зарегистрированных <see cref="ComponentSet"/>'ов с проверкой
+		/// <see cref="ComponentSet.HasElement(WorldState, Entity)"/>. Индекс слота реестра и есть локальный
+		/// индекс компонента — индирекция через глобальный <see cref="TypeId"/> не нужна.
 		/// Для дебага/инспекции — линейный проход по всем типам, не для горячего пути.
 		/// </summary>
-		public static void CollectComponentTypeIds(this WorldState worldState, Entity entity, List<TypeId> result)
+		public static void CollectComponentTypeIds(this WorldState worldState, Entity entity, List<TypeId<IComponent>> result)
 		{
 			result.Clear();
 
@@ -334,7 +336,6 @@ namespace Sapientia.MemoryAllocator
 			if (!manager.IsCreated)
 				return;
 
-			var children = IndexedTypes.GetContextChildren(typeof(IComponent));
 			for (var i = 0; i < manager.Length; i++)
 			{
 				ref var slot = ref manager.GetByIndex(i);
@@ -343,8 +344,7 @@ namespace Sapientia.MemoryAllocator
 				if (!slot.GetPtr(worldState).Value().HasElement(worldState, entity))
 					continue;
 
-				E.ASSERT(i < children.Length);
-				result.Add(children[i]);
+				result.Add(i);
 			}
 		}
 	}

--- a/MemoryAllocator/TypeIndexer/Generator/ComponentCopyGenerator.cs
+++ b/MemoryAllocator/TypeIndexer/Generator/ComponentCopyGenerator.cs
@@ -35,6 +35,8 @@ namespace Sapientia.TypeIndexer
 			EntityOwned,
 			SetOwned,
 			SetLink,
+			ListOwned,
+			ListLink,
 			IgnoreField,
 		}
 
@@ -68,6 +70,7 @@ namespace Sapientia.TypeIndexer
 
 			var flatComponents = new List<Type>();
 			var refComponents = new List<Type>();
+			var skippedComponents = new List<Type>();
 
 			foreach (var type in GetComponentTypes())
 			{
@@ -76,6 +79,9 @@ namespace Sapientia.TypeIndexer
 
 				switch (verdict)
 				{
+					case Verdict.Skip:
+						skippedComponents.Add(type);
+						break;
 					case Verdict.FlatCopy:
 						flatComponents.Add(type);
 						break;
@@ -116,7 +122,7 @@ namespace Sapientia.TypeIndexer
 				Directory.Delete(baseDirectory, true);
 			Directory.CreateDirectory(baseDirectory);
 
-			File.WriteAllText(Path.Combine(baseDirectory, "GeneratedComponentCopier.generated.cs"), EmitDispatcher(flatComponents, refComponents));
+			File.WriteAllText(Path.Combine(baseDirectory, "GeneratedComponentCopier.generated.cs"), EmitDispatcher(flatComponents, refComponents, skippedComponents));
 			File.WriteAllText(Path.Combine(baseDirectory, "_worklist.txt"), report.ToString());
 		}
 
@@ -219,6 +225,22 @@ namespace Sapientia.TypeIndexer
 				plan = new FieldPlan(field.Name, link ? FieldKind.SetLink : FieldKind.SetOwned);
 				return true;
 			}
+			if (IsMemListOfEntity(fieldType))
+			{
+				var link = field.GetCustomAttribute<LinkAttribute>() != null;
+				plan = new FieldPlan(field.Name, link ? FieldKind.ListLink : FieldKind.ListOwned);
+				return true;
+			}
+			if (IsMemArrayOfEntity(fieldType))
+			{
+				var droppedMarker = field.GetCustomAttribute<OwnedAttribute>() != null ? "[Owned]"
+					: field.GetCustomAttribute<LinkAttribute>() != null ? "[Link]"
+					: null;
+				unhandleableReason = droppedMarker != null
+					? $"{field.Name}: {droppedMarker} на MemArray<Entity> ПРОИГНОРИРОВАН - MemArray<Entity> генератором не поддержана (фиксированная длина). Замени на MemList<Entity>/MemHashSet<Entity> либо напиши [ManualCopy]."
+					: $"{field.Name}: MemArray<Entity> генератором не поддержана (фиксированная длина). Замени на MemList<Entity>/MemHashSet<Entity> либо напиши [ManualCopy].";
+				return false;
+			}
 			if (IsFlat(fieldType))
 			{
 				plan = new FieldPlan(field.Name, FieldKind.Flat);
@@ -233,6 +255,20 @@ namespace Sapientia.TypeIndexer
 		{
 			return type.IsGenericType
 				&& type.GetGenericTypeDefinition() == typeof(MemHashSet<>)
+				&& type.GetGenericArguments()[0] == typeof(Entity);
+		}
+
+		private static bool IsMemListOfEntity(Type type)
+		{
+			return type.IsGenericType
+				&& type.GetGenericTypeDefinition() == typeof(MemList<>)
+				&& type.GetGenericArguments()[0] == typeof(Entity);
+		}
+
+		private static bool IsMemArrayOfEntity(Type type)
+		{
+			return type.IsGenericType
+				&& type.GetGenericTypeDefinition() == typeof(MemArray<>)
 				&& type.GetGenericArguments()[0] == typeof(Entity);
 		}
 
@@ -333,6 +369,7 @@ namespace Sapientia.TypeIndexer
 						builder.AppendLine($"\t\t\tentities.Add({plan.name});");
 						break;
 					case FieldKind.SetOwned:
+					case FieldKind.ListOwned:
 						builder.AppendLine($"\t\t\tforeach (var __entity in {plan.name}.GetEnumerable(world))");
 						builder.AppendLine("\t\t\t{");
 						builder.AppendLine("\t\t\t\tentities.Add(__entity);");
@@ -370,6 +407,20 @@ namespace Sapientia.TypeIndexer
 						builder.AppendLine("\t\t\t\t}");
 						builder.AppendLine("\t\t\t}");
 						break;
+					case FieldKind.ListOwned:
+					case FieldKind.ListLink:
+						builder.AppendLine($"\t\t\tif ({plan.name}.IsCreated)");
+						builder.AppendLine("\t\t\t{");
+						builder.AppendLine($"\t\t\t\tcomponent.{plan.name} = new MemList<Entity>(newWS, {plan.name}.Count);");
+						builder.AppendLine($"\t\t\t\tforeach (var __entity in {plan.name}.GetEnumerable(oldWS))");
+						builder.AppendLine("\t\t\t\t{");
+						builder.AppendLine("\t\t\t\t\tif (map.TryGetValue(__entity, out var __mapped))");
+						builder.AppendLine("\t\t\t\t\t{");
+						builder.AppendLine($"\t\t\t\t\t\tcomponent.{plan.name}.Add(newWS, __mapped);");
+						builder.AppendLine("\t\t\t\t\t}");
+						builder.AppendLine("\t\t\t\t}");
+						builder.AppendLine("\t\t\t}");
+						break;
 				}
 			}
 			builder.AppendLine("\t\t}");
@@ -379,19 +430,22 @@ namespace Sapientia.TypeIndexer
 			return builder.ToString();
 		}
 
-		private static string EmitDispatcher(List<Type> flatComponents, List<Type> refComponents)
+		private static string EmitDispatcher(List<Type> flatComponents, List<Type> refComponents, List<Type> skippedComponents)
 		{
 			var builder = new StringBuilder();
 			builder.AppendLine("using Sapientia.Collections;");
 			builder.AppendLine("using Sapientia.MemoryAllocator;");
 			builder.AppendLine("using Sapientia.MemoryAllocator.State;");
 			builder.AppendLine("using Sapientia.TypeIndexer;");
+			builder.AppendLine("using Sapientia;");
+			builder.AppendLine("using WLog;");
 			builder.AppendLine();
 			builder.AppendLine("namespace Sapientia.TypeIndexer.Generated");
 			builder.AppendLine("{");
 			builder.AppendLine("\tpublic sealed class GeneratedComponentCopier : IComponentCopier");
 			builder.AppendLine("\t{");
 			builder.AppendLine("\t\tprivate static System.Collections.Generic.HashSet<int> _copiable;");
+			builder.AppendLine("\t\tprivate static System.Collections.Generic.HashSet<int> _skipped;");
 			builder.AppendLine();
 			builder.AppendLine("\t\t[UnityEngine.RuntimeInitializeOnLoadMethod(UnityEngine.RuntimeInitializeLoadType.BeforeSceneLoad)]");
 			builder.AppendLine("\t\tprivate static void Register()");
@@ -410,6 +464,19 @@ namespace Sapientia.TypeIndexer
 			}
 			builder.AppendLine("\t\t\t};");
 			builder.AppendLine("\t\t\treturn _copiable.Contains((int)typeId);");
+			builder.AppendLine("\t\t}");
+			builder.AppendLine();
+
+			builder.AppendLine("\t\tpublic bool IsSkipped(TypeId typeId)");
+			builder.AppendLine("\t\t{");
+			builder.AppendLine("\t\t\t_skipped ??= new System.Collections.Generic.HashSet<int>");
+			builder.AppendLine("\t\t\t{");
+			foreach (var type in skippedComponents)
+			{
+				builder.AppendLine($"\t\t\t\t(int)TypeIdOf<{type.GetFullName()}>.typeId,");
+			}
+			builder.AppendLine("\t\t\t};");
+			builder.AppendLine("\t\t\treturn _skipped.Contains((int)typeId);");
 			builder.AppendLine("\t\t}");
 			builder.AppendLine();
 
@@ -452,6 +519,14 @@ namespace Sapientia.TypeIndexer
 				builder.AppendLine("\t\t\t\treturn;");
 				builder.AppendLine("\t\t\t}");
 			}
+			builder.AppendLine("\t\t}");
+			builder.AppendLine();
+			builder.AppendLine("\t\tpublic void ReportUnhandled(TypeId typeId)");
+			builder.AppendLine("\t\t{");
+			builder.AppendLine("\t\t\tvar __type = IndexedTypes.GetType(typeId);");
+			builder.AppendLine("\t\t\tvar __name = __type != null ? __type.FullName : ((int)typeId).ToString();");
+			builder.AppendLine("\t\t\tthis.LogError($\"CopyEntityTree: необработанный ссылочный компонент {__name} потеряется при копии. Добавь [GenerateCopy]/[ManualCopy] либо [SkipCopy].\");");
+			builder.AppendLine("\t\t\tE.ASSERT(false, \"CopyEntityTree: необработанный ссылочный компонент \" + __name + \".\");");
 			builder.AppendLine("\t\t}");
 			builder.AppendLine("\t}");
 			builder.AppendLine("}");

--- a/MemoryAllocator/TypeIndexer/Generator/ComponentCopyGenerator.cs
+++ b/MemoryAllocator/TypeIndexer/Generator/ComponentCopyGenerator.cs
@@ -388,7 +388,7 @@ namespace Sapientia.TypeIndexer
 				{
 					case FieldKind.EntityLink:
 					case FieldKind.EntityOwned:
-						builder.AppendLine($"\t\t\tcomponent.{plan.name} = map.Remap({plan.name});");
+						builder.AppendLine($"\t\t\tcomponent.{plan.name} = map.GetOrDefault({plan.name});");
 						break;
 					case FieldKind.IgnoreField:
 						builder.AppendLine($"\t\t\tcomponent.{plan.name} = default;");

--- a/MemoryAllocator/TypeIndexer/Generator/ComponentCopyGenerator.cs
+++ b/MemoryAllocator/TypeIndexer/Generator/ComponentCopyGenerator.cs
@@ -122,7 +122,7 @@ namespace Sapientia.TypeIndexer
 				Directory.Delete(baseDirectory, true);
 			Directory.CreateDirectory(baseDirectory);
 
-			File.WriteAllText(Path.Combine(baseDirectory, "GeneratedComponentCopier.generated.cs"), EmitDispatcher(flatComponents, refComponents, skippedComponents));
+			File.WriteAllText(Path.Combine(baseDirectory, "GeneratedComponentCopier.generated.cs"), EmitRegistration(flatComponents, refComponents, skippedComponents));
 			File.WriteAllText(Path.Combine(baseDirectory, "_worklist.txt"), report.ToString());
 		}
 
@@ -430,7 +430,12 @@ namespace Sapientia.TypeIndexer
 			return builder.ToString();
 		}
 
-		private static string EmitDispatcher(List<Type> flatComponents, List<Type> refComponents, List<Type> skippedComponents)
+		/// <summary>
+		/// Эмитит ТОЛЬКО данные регистрации (без класса-диспатчера): per-type thunk-и Append/Copy и метод
+		/// <c>Register</c>, который запекает их в <see cref="ComponentCopier"/> по локальному индексу.
+		/// Тело диспатча живёт руками в Sapientia (ComponentCopier), здесь только game-side обвязка.
+		/// </summary>
+		private static string EmitRegistration(List<Type> flatComponents, List<Type> refComponents, List<Type> skippedComponents)
 		{
 			var builder = new StringBuilder();
 			builder.AppendLine("using Sapientia.Collections;");
@@ -442,90 +447,74 @@ namespace Sapientia.TypeIndexer
 			builder.AppendLine();
 			builder.AppendLine("namespace Sapientia.TypeIndexer.Generated");
 			builder.AppendLine("{");
-			builder.AppendLine("\tpublic sealed class GeneratedComponentCopier : IComponentCopier");
+			builder.AppendLine("\tpublic static class GeneratedComponentCopier");
 			builder.AppendLine("\t{");
-			builder.AppendLine("\t\tprivate static System.Collections.Generic.HashSet<int> _copiable;");
-			builder.AppendLine("\t\tprivate static System.Collections.Generic.HashSet<int> _skipped;");
+			builder.AppendLine("\t\tprivate static readonly WLogContext W_CONTEXT = WLogContext.Create(\"ComponentCopier\");");
 			builder.AppendLine();
 			builder.AppendLine("\t\t[UnityEngine.RuntimeInitializeOnLoadMethod(UnityEngine.RuntimeInitializeLoadType.BeforeSceneLoad)]");
 			builder.AppendLine("\t\tprivate static void Register()");
 			builder.AppendLine("\t\t{");
-			builder.AppendLine("\t\t\tGeneratedCopier.SetCopier(new GeneratedComponentCopier());");
-			builder.AppendLine("\t\t}");
+			builder.AppendLine("\t\t\tvar copier = new ComponentCopier();");
 			builder.AppendLine();
-
-			builder.AppendLine("\t\tpublic bool IsCopiable(TypeId typeId)");
-			builder.AppendLine("\t\t{");
-			builder.AppendLine("\t\t\t_copiable ??= new System.Collections.Generic.HashSet<int>");
-			builder.AppendLine("\t\t\t{");
-			foreach (var type in flatComponents.Concat(refComponents))
-			{
-				builder.AppendLine($"\t\t\t\t(int)TypeIdOf<{type.GetFullName()}>.typeId,");
-			}
-			builder.AppendLine("\t\t\t};");
-			builder.AppendLine("\t\t\treturn _copiable.Contains((int)typeId);");
-			builder.AppendLine("\t\t}");
-			builder.AppendLine();
-
-			builder.AppendLine("\t\tpublic bool IsSkipped(TypeId typeId)");
-			builder.AppendLine("\t\t{");
-			builder.AppendLine("\t\t\t_skipped ??= new System.Collections.Generic.HashSet<int>");
-			builder.AppendLine("\t\t\t{");
-			foreach (var type in skippedComponents)
-			{
-				builder.AppendLine($"\t\t\t\t(int)TypeIdOf<{type.GetFullName()}>.typeId,");
-			}
-			builder.AppendLine("\t\t\t};");
-			builder.AppendLine("\t\t\treturn _skipped.Contains((int)typeId);");
-			builder.AppendLine("\t\t}");
-			builder.AppendLine();
-
-			builder.AppendLine("\t\tpublic void AppendEntities(TypeId typeId, WorldState world, Entity entity, ref UnsafeList<Entity> frontier)");
-			builder.AppendLine("\t\t{");
-			builder.AppendLine("\t\t\tvar __id = (int)typeId;");
-			foreach (var type in refComponents)
-			{
-				var fullName = type.GetFullName();
-				builder.AppendLine($"\t\t\tif (__id == (int)TypeIdOf<{fullName}>.typeId)");
-				builder.AppendLine("\t\t\t{");
-				builder.AppendLine($"\t\t\t\tvar __component = new ComponentSetContext<{fullName}>(world).ReadElement(entity);");
-				builder.AppendLine("\t\t\t\t__component.AppendEntities(world, ref frontier);");
-				builder.AppendLine("\t\t\t\treturn;");
-				builder.AppendLine("\t\t\t}");
-			}
-			builder.AppendLine("\t\t}");
-			builder.AppendLine();
-
-			builder.AppendLine("\t\tpublic void CopyComponent(TypeId typeId, WorldState oldWS, WorldState newWS, Entity oldEntity, Entity newEntity, in UnsafeDictionary<Entity, Entity> map)");
-			builder.AppendLine("\t\t{");
-			builder.AppendLine("\t\t\tvar __id = (int)typeId;");
 			foreach (var type in flatComponents)
 			{
 				var fullName = type.GetFullName();
-				builder.AppendLine($"\t\t\tif (__id == (int)TypeIdOf<{fullName}>.typeId)");
-				builder.AppendLine("\t\t\t{");
-				builder.AppendLine($"\t\t\t\tref var __dst = ref new ComponentSetContext<{fullName}>(newWS).GetElement(newEntity);");
-				builder.AppendLine($"\t\t\t\t__dst = new ComponentSetContext<{fullName}>(oldWS).ReadElement(oldEntity);");
-				builder.AppendLine("\t\t\t\treturn;");
-				builder.AppendLine("\t\t\t}");
+				builder.AppendLine($"\t\t\tcopier.Register(TypeIdOf<IComponent, {fullName}>.typeId, null, Copy_{type.Name});");
 			}
+			builder.AppendLine();
 			foreach (var type in refComponents)
 			{
 				var fullName = type.GetFullName();
-				builder.AppendLine($"\t\t\tif (__id == (int)TypeIdOf<{fullName}>.typeId)");
-				builder.AppendLine("\t\t\t{");
-				builder.AppendLine($"\t\t\t\tref var __dst = ref new ComponentSetContext<{fullName}>(newWS).GetElement(newEntity);");
-				builder.AppendLine($"\t\t\t\t__dst = oldWS.Copy<{fullName}>(oldEntity, newWS, in map);");
-				builder.AppendLine("\t\t\t\treturn;");
-				builder.AppendLine("\t\t\t}");
+				builder.AppendLine($"\t\t\tcopier.Register(TypeIdOf<IComponent, {fullName}>.typeId, Append_{type.Name}, Copy_{type.Name});");
 			}
+			builder.AppendLine();
+			foreach (var type in skippedComponents)
+			{
+				var fullName = type.GetFullName();
+				builder.AppendLine($"\t\t\tcopier.MarkSkipped(TypeIdOf<IComponent, {fullName}>.typeId);");
+			}
+			builder.AppendLine();
+			builder.AppendLine("\t\t\tcopier.SetUnhandledReporter(ReportUnhandled);");
+			builder.AppendLine("\t\t\tGeneratedCopier.SetCopier(copier);");
 			builder.AppendLine("\t\t}");
 			builder.AppendLine();
-			builder.AppendLine("\t\tpublic void ReportUnhandled(TypeId typeId)");
+
+			foreach (var type in flatComponents)
+			{
+				var fullName = type.GetFullName();
+				builder.AppendLine($"\t\tprivate static void Copy_{type.Name}(WorldState oldWS, WorldState newWS, Entity oldEntity, Entity newEntity, in UnsafeDictionary<Entity, Entity> map)");
+				builder.AppendLine("\t\t{");
+				builder.AppendLine($"\t\t\tref var __dst = ref new ComponentSetContext<{fullName}>(newWS).GetElement(newEntity);");
+				builder.AppendLine($"\t\t\t__dst = new ComponentSetContext<{fullName}>(oldWS).ReadElement(oldEntity);");
+				builder.AppendLine("\t\t}");
+				builder.AppendLine();
+			}
+
+			foreach (var type in refComponents)
+			{
+				var fullName = type.GetFullName();
+				builder.AppendLine($"\t\tprivate static void Append_{type.Name}(WorldState world, Entity entity, ref UnsafeList<Entity> frontier)");
+				builder.AppendLine("\t\t{");
+				builder.AppendLine($"\t\t\tvar __component = new ComponentSetContext<{fullName}>(world).ReadElement(entity);");
+				builder.AppendLine("\t\t\t__component.AppendEntities(world, ref frontier);");
+				builder.AppendLine("\t\t}");
+				builder.AppendLine();
+				builder.AppendLine($"\t\tprivate static void Copy_{type.Name}(WorldState oldWS, WorldState newWS, Entity oldEntity, Entity newEntity, in UnsafeDictionary<Entity, Entity> map)");
+				builder.AppendLine("\t\t{");
+				builder.AppendLine($"\t\t\tref var __dst = ref new ComponentSetContext<{fullName}>(newWS).GetElement(newEntity);");
+				builder.AppendLine($"\t\t\t__dst = oldWS.Copy<{fullName}>(oldEntity, newWS, in map);");
+				builder.AppendLine("\t\t}");
+				builder.AppendLine();
+			}
+
+			// Имя типа берём через локальный индекс -> children -> глобальный TypeId. Прямой (TypeId)localId
+			// дал бы сырой копир id без валидации = чужой тип, диагностика соврала бы.
+			builder.AppendLine("\t\tprivate static void ReportUnhandled(TypeId<IComponent> localId)");
 			builder.AppendLine("\t\t{");
-			builder.AppendLine("\t\t\tvar __type = IndexedTypes.GetType(typeId);");
-			builder.AppendLine("\t\t\tvar __name = __type != null ? __type.FullName : ((int)typeId).ToString();");
-			builder.AppendLine("\t\t\tthis.LogError($\"CopyEntityTree: необработанный ссылочный компонент {__name} потеряется при копии. Добавь [GenerateCopy]/[ManualCopy] либо [SkipCopy].\");");
+			builder.AppendLine("\t\t\tvar __globalTypeId = IndexedTypes.GetContextChildren(typeof(IComponent))[(int)localId];");
+			builder.AppendLine("\t\t\tvar __type = __globalTypeId.Type;");
+			builder.AppendLine("\t\t\tvar __name = __type != null ? __type.FullName : ((int)localId).ToString();");
+			builder.AppendLine("\t\t\tW_CONTEXT.LogError($\"CopyEntityTree: необработанный ссылочный компонент {__name} потеряется при копии. Добавь [GenerateCopy]/[ManualCopy] либо [SkipCopy].\");");
 			builder.AppendLine("\t\t\tE.ASSERT(false, \"CopyEntityTree: необработанный ссылочный компонент \" + __name + \".\");");
 			builder.AppendLine("\t\t}");
 			builder.AppendLine("\t}");

--- a/MemoryAllocator/TypeIndexer/Generator/ComponentCopyGenerator.cs
+++ b/MemoryAllocator/TypeIndexer/Generator/ComponentCopyGenerator.cs
@@ -1,0 +1,462 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Reflection;
+using System.Text;
+using Sapientia.Extensions.Reflection;
+using Sapientia.MemoryAllocator;
+using Sapientia.MemoryAllocator.State;
+
+namespace Sapientia.TypeIndexer
+{
+	/// <summary>
+	/// Editor-генератор копиров компонентов (opt-out). Рефлексией проходит по всем <see cref="IComponent"/>:
+	/// плоский компонент копируется значением прямо в диспатче; ссылочный с меткой
+	/// <see cref="GenerateCopyAttribute"/> получает partial <see cref="ICopiable{T}"/>; <see cref="ManualCopyAttribute"/>
+	/// идёт в диспатч без генерации partial; <see cref="SkipCopyAttribute"/> исключается; ссылочный без метки
+	/// попадает в лог-отчёт (worklist).
+	/// </summary>
+	public static class ComponentCopyGenerator
+	{
+		private const string GeneratorName = nameof(ComponentCopyGenerator);
+
+		private const BindingFlags InstanceFields = BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic;
+
+		private static readonly HashSet<Type> MemCollectionDefinitions = new()
+		{
+			typeof(MemArray<>), typeof(MemList<>), typeof(MemHashSet<>), typeof(MemDictionary<,>), typeof(MemSparseSet<>),
+		};
+
+		private enum FieldKind
+		{
+			Flat,
+			EntityLink,
+			EntityOwned,
+			SetOwned,
+			SetLink,
+			IgnoreField,
+		}
+
+		private enum Verdict
+		{
+			Skip,
+			ManualDispatch,
+			FlatCopy,
+			Generate,
+			WorklistRefs,
+			WorklistUnhandleable,
+			ErrorMarkedButUnhandleable,
+		}
+
+		private readonly struct FieldPlan
+		{
+			public readonly string name;
+			public readonly FieldKind kind;
+
+			public FieldPlan(string name, FieldKind kind)
+			{
+				this.name = name;
+				this.kind = kind;
+			}
+		}
+
+		public static void GenerateCopiers(string baseGenerationFolder, Dictionary<string, string> assemblyNameToPath)
+		{
+			var report = new StringBuilder();
+			var generatedByAssembly = new Dictionary<string, List<(Type type, List<FieldPlan> plans)>>();
+
+			var flatComponents = new List<Type>();
+			var refComponents = new List<Type>();
+
+			foreach (var type in GetComponentTypes())
+			{
+				var verdict = Classify(type, out var plans, out var reason);
+				report.AppendLine($"{verdict}\t{type.GetFullName()}{(reason != null ? "\t" + reason : string.Empty)}");
+
+				switch (verdict)
+				{
+					case Verdict.FlatCopy:
+						flatComponents.Add(type);
+						break;
+					case Verdict.ManualDispatch:
+						refComponents.Add(type);
+						break;
+					case Verdict.Generate:
+						refComponents.Add(type);
+						var assemblyName = type.Assembly.GetName().Name;
+						if (!generatedByAssembly.TryGetValue(assemblyName, out var list))
+						{
+							list = new List<(Type, List<FieldPlan>)>();
+							generatedByAssembly.Add(assemblyName, list);
+						}
+						list.Add((type, plans));
+						break;
+				}
+			}
+
+			foreach (var (assemblyName, list) in generatedByAssembly)
+			{
+				if (!assemblyNameToPath.TryGetValue(assemblyName, out var assemblyDir))
+				{
+					report.AppendLine($"NoAssemblyPath\t{assemblyName}\tпропущено {list.Count} компонентов: некуда положить partial");
+					continue;
+				}
+
+				var directory = PrepareDirectory(assemblyDir);
+				Directory.CreateDirectory(directory);
+				foreach (var (type, plans) in list)
+				{
+					File.WriteAllText(Path.Combine(directory, $"{type.GetFullName()}.Copy.generated.cs"), EmitComponentPartial(type, plans));
+				}
+			}
+
+			var baseDirectory = Path.Combine(baseGenerationFolder, GeneratorName);
+			if (Directory.Exists(baseDirectory))
+				Directory.Delete(baseDirectory, true);
+			Directory.CreateDirectory(baseDirectory);
+
+			File.WriteAllText(Path.Combine(baseDirectory, "GeneratedComponentCopier.generated.cs"), EmitDispatcher(flatComponents, refComponents));
+			File.WriteAllText(Path.Combine(baseDirectory, "_worklist.txt"), report.ToString());
+		}
+
+		private static string PrepareDirectory(string assemblyDir)
+		{
+			var directory = Path.Combine(Path.Combine(assemblyDir, "_scripts.generated"), GeneratorName);
+			if (Directory.Exists(directory))
+				Directory.Delete(directory, true);
+			return directory;
+		}
+
+		private static Type[] GetComponentTypes()
+		{
+			return AppDomain.CurrentDomain.GetAssemblies()
+				.SelectMany(SafeGetTypes)
+				.Where(type => type.IsValueType
+					&& !type.IsAbstract
+					&& !type.IsGenericType
+					&& type != typeof(IgnoreEntityCopy)
+					&& typeof(IComponent).IsAssignableFrom(type))
+				.OrderBy(type => type.GetFullName())
+				.ToArray();
+		}
+
+		private static IEnumerable<Type> SafeGetTypes(Assembly assembly)
+		{
+			try
+			{
+				return assembly.GetTypes();
+			}
+			catch (ReflectionTypeLoadException exception)
+			{
+				return exception.Types.Where(type => type != null).Select(type => type!);
+			}
+		}
+
+		private static Verdict Classify(Type type, out List<FieldPlan> plans, out string? reason)
+		{
+			plans = new List<FieldPlan>();
+			reason = null;
+
+			if (type.HasAttribute<SkipCopyAttribute>())
+				return Verdict.Skip;
+			if (type.HasAttribute<ManualCopyAttribute>())
+				return Verdict.ManualDispatch;
+
+			var marked = type.HasAttribute<GenerateCopyAttribute>();
+
+			if (type.IsExplicitLayout)
+			{
+				reason = "explicit-layout (union)";
+				return marked ? Verdict.ErrorMarkedButUnhandleable : Verdict.WorklistUnhandleable;
+			}
+
+			var hasRefs = false;
+			foreach (var field in type.GetFields(InstanceFields))
+			{
+				if (!TryClassifyField(field, out var plan, out var fieldReason))
+				{
+					plans.Clear();
+					reason = fieldReason;
+					return marked ? Verdict.ErrorMarkedButUnhandleable : Verdict.WorklistUnhandleable;
+				}
+
+				if (plan.kind != FieldKind.Flat && plan.kind != FieldKind.IgnoreField)
+					hasRefs = true;
+				plans.Add(plan);
+			}
+
+			if (!hasRefs)
+				return Verdict.FlatCopy;
+
+			if (marked)
+				return Verdict.Generate;
+
+			reason = "handleable-with-refs";
+			return Verdict.WorklistRefs;
+		}
+
+		private static bool TryClassifyField(FieldInfo field, out FieldPlan plan, out string? unhandleableReason)
+		{
+			plan = default;
+			unhandleableReason = null;
+			var fieldType = field.FieldType;
+
+			if (field.GetCustomAttribute<IgnoreCopyAttribute>() != null)
+			{
+				plan = new FieldPlan(field.Name, FieldKind.IgnoreField);
+				return true;
+			}
+			if (fieldType == typeof(Entity))
+			{
+				var owned = field.GetCustomAttribute<OwnedAttribute>() != null;
+				plan = new FieldPlan(field.Name, owned ? FieldKind.EntityOwned : FieldKind.EntityLink);
+				return true;
+			}
+			if (IsMemHashSetOfEntity(fieldType))
+			{
+				var link = field.GetCustomAttribute<LinkAttribute>() != null;
+				plan = new FieldPlan(field.Name, link ? FieldKind.SetLink : FieldKind.SetOwned);
+				return true;
+			}
+			if (IsFlat(fieldType))
+			{
+				plan = new FieldPlan(field.Name, FieldKind.Flat);
+				return true;
+			}
+
+			unhandleableReason = $"{field.Name}: {fieldType.Name}";
+			return false;
+		}
+
+		private static bool IsMemHashSetOfEntity(Type type)
+		{
+			return type.IsGenericType
+				&& type.GetGenericTypeDefinition() == typeof(MemHashSet<>)
+				&& type.GetGenericArguments()[0] == typeof(Entity);
+		}
+
+		private static bool IsMemCollection(Type type)
+		{
+			return type.IsGenericType && MemCollectionDefinitions.Contains(type.GetGenericTypeDefinition());
+		}
+
+		private static bool IsFlat(Type type)
+		{
+			return !ContainsEntity(type, new HashSet<Type>()) && !ContainsArenaHandle(type, new HashSet<Type>());
+		}
+
+		private static bool ContainsEntity(Type type, HashSet<Type> visited)
+		{
+			if (type == typeof(Entity))
+				return true;
+			if (type.IsPrimitive || type.IsEnum || type.IsPointer)
+				return false;
+			if (!visited.Add(type))
+				return false;
+			if (IsMemCollection(type))
+				return type.GetGenericArguments().Any(argument => ContainsEntity(argument, visited));
+			if (!type.IsValueType)
+				return false;
+
+			try
+			{
+				foreach (var field in type.GetFields(InstanceFields))
+				{
+					if (ContainsEntity(field.FieldType, visited))
+						return true;
+				}
+			}
+			catch
+			{
+				return false;
+			}
+			return false;
+		}
+
+		private static bool ContainsArenaHandle(Type type, HashSet<Type> visited)
+		{
+			if (IsArenaHandleLeaf(type) || IsMemCollection(type))
+				return true;
+			if (type.IsPrimitive || type.IsEnum || type.IsPointer)
+				return false;
+			if (!visited.Add(type))
+				return false;
+			if (!type.IsValueType)
+				return false;
+
+			try
+			{
+				foreach (var field in type.GetFields(InstanceFields))
+				{
+					if (ContainsArenaHandle(field.FieldType, visited))
+						return true;
+				}
+			}
+			catch
+			{
+				return true;
+			}
+			return false;
+		}
+
+		private static bool IsArenaHandleLeaf(Type type)
+		{
+			var name = type.Name;
+			return name == "MemPtr"
+				|| name.StartsWith("SafePtr")
+				|| name.StartsWith("CachedPtr")
+				|| name.StartsWith("ProxyPtr")
+				|| name.StartsWith("IndexedPtr");
+		}
+
+		private static string EmitComponentPartial(Type type, List<FieldPlan> plans)
+		{
+			var name = type.Name;
+			var builder = new StringBuilder();
+			builder.AppendLine("using Sapientia.Collections;");
+			builder.AppendLine("using Sapientia.MemoryAllocator;");
+			builder.AppendLine("using Sapientia.MemoryAllocator.State;");
+			builder.AppendLine();
+			builder.AppendLine($"namespace {type.Namespace}");
+			builder.AppendLine("{");
+			builder.AppendLine($"\tpublic partial struct {name} : ICopiable<{name}>");
+			builder.AppendLine("\t{");
+
+			builder.AppendLine("\t\tpublic void AppendEntities(WorldState world, ref UnsafeList<Entity> entities)");
+			builder.AppendLine("\t\t{");
+			foreach (var plan in plans)
+			{
+				switch (plan.kind)
+				{
+					case FieldKind.EntityOwned:
+						builder.AppendLine($"\t\t\tentities.Add({plan.name});");
+						break;
+					case FieldKind.SetOwned:
+						builder.AppendLine($"\t\t\tforeach (var __entity in {plan.name}.GetEnumerable(world))");
+						builder.AppendLine("\t\t\t{");
+						builder.AppendLine("\t\t\t\tentities.Add(__entity);");
+						builder.AppendLine("\t\t\t}");
+						break;
+				}
+			}
+			builder.AppendLine("\t\t}");
+			builder.AppendLine();
+
+			builder.AppendLine($"\t\tpublic void InnerCopy(WorldState oldWS, WorldState newWS, ref {name} component, in UnsafeDictionary<Entity, Entity> map)");
+			builder.AppendLine("\t\t{");
+			foreach (var plan in plans)
+			{
+				switch (plan.kind)
+				{
+					case FieldKind.EntityLink:
+					case FieldKind.EntityOwned:
+						builder.AppendLine($"\t\t\tcomponent.{plan.name} = map.Remap({plan.name});");
+						break;
+					case FieldKind.IgnoreField:
+						builder.AppendLine($"\t\t\tcomponent.{plan.name} = default;");
+						break;
+					case FieldKind.SetOwned:
+					case FieldKind.SetLink:
+						builder.AppendLine($"\t\t\tif ({plan.name}.IsCreated)");
+						builder.AppendLine("\t\t\t{");
+						builder.AppendLine($"\t\t\t\tcomponent.{plan.name} = new MemHashSet<Entity>(newWS, {plan.name}.Count);");
+						builder.AppendLine($"\t\t\t\tforeach (var __entity in {plan.name}.GetEnumerable(oldWS))");
+						builder.AppendLine("\t\t\t\t{");
+						builder.AppendLine("\t\t\t\t\tif (map.TryGetValue(__entity, out var __mapped))");
+						builder.AppendLine("\t\t\t\t\t{");
+						builder.AppendLine($"\t\t\t\t\t\tcomponent.{plan.name}.Add(newWS, __mapped);");
+						builder.AppendLine("\t\t\t\t\t}");
+						builder.AppendLine("\t\t\t\t}");
+						builder.AppendLine("\t\t\t}");
+						break;
+				}
+			}
+			builder.AppendLine("\t\t}");
+			builder.AppendLine("\t}");
+			builder.AppendLine("}");
+
+			return builder.ToString();
+		}
+
+		private static string EmitDispatcher(List<Type> flatComponents, List<Type> refComponents)
+		{
+			var builder = new StringBuilder();
+			builder.AppendLine("using Sapientia.Collections;");
+			builder.AppendLine("using Sapientia.MemoryAllocator;");
+			builder.AppendLine("using Sapientia.MemoryAllocator.State;");
+			builder.AppendLine("using Sapientia.TypeIndexer;");
+			builder.AppendLine();
+			builder.AppendLine("namespace Sapientia.TypeIndexer.Generated");
+			builder.AppendLine("{");
+			builder.AppendLine("\tpublic sealed class GeneratedComponentCopier : IComponentCopier");
+			builder.AppendLine("\t{");
+			builder.AppendLine("\t\tprivate static System.Collections.Generic.HashSet<int> _copiable;");
+			builder.AppendLine();
+			builder.AppendLine("\t\t[UnityEngine.RuntimeInitializeOnLoadMethod(UnityEngine.RuntimeInitializeLoadType.BeforeSceneLoad)]");
+			builder.AppendLine("\t\tprivate static void Register()");
+			builder.AppendLine("\t\t{");
+			builder.AppendLine("\t\t\tGeneratedCopier.SetCopier(new GeneratedComponentCopier());");
+			builder.AppendLine("\t\t}");
+			builder.AppendLine();
+
+			builder.AppendLine("\t\tpublic bool IsCopiable(TypeId typeId)");
+			builder.AppendLine("\t\t{");
+			builder.AppendLine("\t\t\t_copiable ??= new System.Collections.Generic.HashSet<int>");
+			builder.AppendLine("\t\t\t{");
+			foreach (var type in flatComponents.Concat(refComponents))
+			{
+				builder.AppendLine($"\t\t\t\t(int)TypeIdOf<{type.GetFullName()}>.typeId,");
+			}
+			builder.AppendLine("\t\t\t};");
+			builder.AppendLine("\t\t\treturn _copiable.Contains((int)typeId);");
+			builder.AppendLine("\t\t}");
+			builder.AppendLine();
+
+			builder.AppendLine("\t\tpublic void AppendEntities(TypeId typeId, WorldState world, Entity entity, ref UnsafeList<Entity> frontier)");
+			builder.AppendLine("\t\t{");
+			builder.AppendLine("\t\t\tvar __id = (int)typeId;");
+			foreach (var type in refComponents)
+			{
+				var fullName = type.GetFullName();
+				builder.AppendLine($"\t\t\tif (__id == (int)TypeIdOf<{fullName}>.typeId)");
+				builder.AppendLine("\t\t\t{");
+				builder.AppendLine($"\t\t\t\tvar __component = new ComponentSetContext<{fullName}>(world).ReadElement(entity);");
+				builder.AppendLine("\t\t\t\t__component.AppendEntities(world, ref frontier);");
+				builder.AppendLine("\t\t\t\treturn;");
+				builder.AppendLine("\t\t\t}");
+			}
+			builder.AppendLine("\t\t}");
+			builder.AppendLine();
+
+			builder.AppendLine("\t\tpublic void CopyComponent(TypeId typeId, WorldState oldWS, WorldState newWS, Entity oldEntity, Entity newEntity, in UnsafeDictionary<Entity, Entity> map)");
+			builder.AppendLine("\t\t{");
+			builder.AppendLine("\t\t\tvar __id = (int)typeId;");
+			foreach (var type in flatComponents)
+			{
+				var fullName = type.GetFullName();
+				builder.AppendLine($"\t\t\tif (__id == (int)TypeIdOf<{fullName}>.typeId)");
+				builder.AppendLine("\t\t\t{");
+				builder.AppendLine($"\t\t\t\tref var __dst = ref new ComponentSetContext<{fullName}>(newWS).GetElement(newEntity);");
+				builder.AppendLine($"\t\t\t\t__dst = new ComponentSetContext<{fullName}>(oldWS).ReadElement(oldEntity);");
+				builder.AppendLine("\t\t\t\treturn;");
+				builder.AppendLine("\t\t\t}");
+			}
+			foreach (var type in refComponents)
+			{
+				var fullName = type.GetFullName();
+				builder.AppendLine($"\t\t\tif (__id == (int)TypeIdOf<{fullName}>.typeId)");
+				builder.AppendLine("\t\t\t{");
+				builder.AppendLine($"\t\t\t\tref var __dst = ref new ComponentSetContext<{fullName}>(newWS).GetElement(newEntity);");
+				builder.AppendLine($"\t\t\t\t__dst = oldWS.Copy<{fullName}>(oldEntity, newWS, in map);");
+				builder.AppendLine("\t\t\t\treturn;");
+				builder.AppendLine("\t\t\t}");
+			}
+			builder.AppendLine("\t\t}");
+			builder.AppendLine("\t}");
+			builder.AppendLine("}");
+
+			return builder.ToString();
+		}
+	}
+}

--- a/MemoryAllocator/TypeIndexer/Generator/ComponentCopyGenerator.cs.meta
+++ b/MemoryAllocator/TypeIndexer/Generator/ComponentCopyGenerator.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 93827adbc7389d54a936dc847fa975e8

--- a/MemoryAllocator/TypeIndexer/Generator/UnityTypeIndexerAutoGenerator.cs
+++ b/MemoryAllocator/TypeIndexer/Generator/UnityTypeIndexerAutoGenerator.cs
@@ -17,6 +17,7 @@ namespace Sapientia.TypeIndexer
 			var assemblyNameToPath = ReflectionExt.GetAssemblyNameToPath();
 
 			InterfaceProxyGenerator.GenerateProxies(baseGenerationFolder, assemblyNameToPath);
+			ComponentCopyGenerator.GenerateCopiers(baseGenerationFolder, assemblyNameToPath);
 			AssetDatabase.Refresh();
 		}
 	}


### PR DESCRIPTION
# Sapientia: движок копирования сущностей между мирами

Переиспользуемый движок: копирует сущность вместе с её дочерним поддеревом из одного `WorldState` в другой. Игровой логики тут нет - она в основном репозитории.

**[Парный PR (игровая часть + как тестировалось)](https://github.com/Winzardy/Survivor.Client/pull/311)** 

## Зачем
Часть общей задачи перенос состояния между этапами уровня. Движок вынесен в Sapientia, потому что он общий и не знает ничего про геймплей - его можно переиспользовать в других проектах.

## Что делает
```csharp
Entity copy = srcWorld.CopyEntityTree(root, dstWorld);
```
Копирует `root` и всё, чем он владеет, в другой мир и возвращает корень копии. Ссылки **внутри** поддерева перенастраиваются на новые сущности; ссылки **наружу** (на то, что не копировали) становятся пустыми (`Entity.EMPTY`).

## Как устроено
Три прохода (`WorldStateCopyExtensions.CopyEntityTree`):

1. **Собрать поддерево** - обойти владение от корня вниз.
2. **Создать копии** - создать пустые сущности под каждую и запомнить пары старая-новая.
3. **Скопировать значения** - перенести поля и перенастроить ссылки по таблице пар.

Проходов три, а не два, потому что для перенастройки ссылки целевая сущность уже должна существовать. Поэтому создание вынесено в отдельный проход до копирования значений.

## Что копировать - решает кодоген
Генератор (`ComponentCopyGenerator`) проходит по всем компонентам и классифицирует их по маркерам:

| Маркер на компоненте | Поведение |
|---|---|
| нет ссылок | копируется значением, без генерации |
| `[GenerateCopy]` | генерится копир, поля-ссылки перенастраиваются |
| `[ManualCopy]` | копир пишется руками (для нетривиальных структур) |
| `[SkipCopy]` | намеренно не копируется |
| ссылочный **без** маркера | попадает в отчёт `_worklist.txt` - видно, что не покрыто |

Маркеры полей: `[Owned]` - сущность тянется в копию; `[Link]` - только перенастройка ссылки; `[IgnoreCopy]` - поле обнуляется.

## Без молчаливых потерь
Если в копию попал ссылочный компонент 
> Ссылочный компонент - компонент, у которого внутри ссылки на другие сущности поле Entity или коллекция Entity или Mem-данные, такой нельзя копировать значением - после переноса в новый мир ссылка будет смотреть в старый поэтому ему нужен маркер, как копировать, плоский только числа/enum копируется как есть

без маркера, раньше он терялся бы тихо (особенно в релизе, где проверки вырезаны). Теперь движок сообщает об этом через мост `IComponentCopier.ReportUnhandled`: в релизе пишется ошибка в лог, в DEBUG загрузка падает. Что именно не покрыто - в `_worklist.txt`.

Диагностика идёт через мост `IComponentCopier`, потому что Sapientia не видит игровой логгер напрямую - туда же, куда уходит и сама генерёжка копиров.

## Отдельный коммит: фикс утечки
`UnsafeSparseSet.RemoveSwapBack(out removedValue)` не заполнял `out` - всегда возвращал `default`. Из-за этого `ObstacleLayer.Remove` освобождал пустой список, а реальный (`NoTrack`) утекал. Фикс в одну строку, вынесен отдельным коммитом. Баг не из этой задачи давно висел

## Файлы
- `MemoryAllocator/State/Copy/` - движок (`WorldStateCopyExtensions`, `IComponentCopier`, `GeneratedCopier`, маркеры).
- `MemoryAllocator/TypeIndexer/Generator/ComponentCopyGenerator.cs` - генератор копиров.
- `[SkipCopy]` на нескольких служебных компонентах жизненного цикла - колбэки (kill/activity) с прокси и временные request-компоненты уничтожения. В копию они не нужны.
- `Collections/Unsafe/UnsafeSparseSet.cs` - фикс выше.